### PR TITLE
Remove src from import statements in tests

### DIFF
--- a/tests/boilerplate/test_archivers.py
+++ b/tests/boilerplate/test_archivers.py
@@ -5,8 +5,8 @@ from zipfile import ZIP_DEFLATED, ZipFile
 
 import pytest
 
-from src.boilerplate.archiver import GTFSRTArchiver
-from src.boilerplate.enums import CAVLDataFormat
+from boilerplate.archiver import GTFSRTArchiver
+from boilerplate.enums import CAVLDataFormat
 from tests.mock_db import MockedDB
 
 ARCHIVE_MODULE = "src.boilerplate.archiver"

--- a/tests/periodic_tasks/test_create_gtfsrt_zipfile.py
+++ b/tests/periodic_tasks/test_create_gtfsrt_zipfile.py
@@ -1,6 +1,6 @@
 import unittest
 from unittest.mock import patch
-from src.periodic_tasks.create_gtfsrt_zip import lambda_handler
+from periodic_tasks.create_gtfsrt_zip import lambda_handler
 
 MODULE_PATH = "src.periodic_tasks.create_gtfsrt_zip"
 

--- a/tests/periodic_tasks/test_create_sirivm_tfl_zipfile.py
+++ b/tests/periodic_tasks/test_create_sirivm_tfl_zipfile.py
@@ -1,6 +1,6 @@
 import unittest
 from unittest.mock import patch
-from src.periodic_tasks.create_sirivm_tfl_zip import lambda_handler
+from periodic_tasks.create_sirivm_tfl_zip import lambda_handler
 
 MODULE_PATH = "src.periodic_tasks.create_sirivm_tfl_zip"
 

--- a/tests/periodic_tasks/test_create_sirivm_zipfile.py
+++ b/tests/periodic_tasks/test_create_sirivm_zipfile.py
@@ -1,6 +1,6 @@
 import unittest
 from unittest.mock import patch
-from src.periodic_tasks.create_sirivm_zip import lambda_handler
+from periodic_tasks.create_sirivm_zip import lambda_handler
 
 MODULE_PATH = "src.periodic_tasks.create_sirivm_zip"
 

--- a/tests/timetables_etl/test_app.py
+++ b/tests/timetables_etl/test_app.py
@@ -1,4 +1,4 @@
-from src.timetables_etl.app import lambda_handler
+from timetables_etl.app import lambda_handler
 
 
 def test_app():


### PR DESCRIPTION
I noticed that in tests we're importing the code under test from `src.boilerplate.*`, `src.backend.*` etc.

This is unnecessary because our [pytest.ini](https://github.com/department-for-transport-BODS/bods-backend/blob/dev/pytest.ini#L2) already adds the `src` folder to the python path. Hence we can just reference them the same way we do in the actual source code.

I also ran into another problem importing from `src` when it comes to testing exceptions, demonstrated in this example:
```
from boilerplate.exceptions import PipelineException

def func_under_test():
  raise PipelineException()
```

```
from src.boilerplate.exceptions import PipelineException

def test_func_under_test():
  with pytest.raises(PipelineException):
    func_under_test()
```

The above test will fail, because pytest doesn't recognize that `src.boilerplate.exceptions.PipelineException` is the same as `boilerplate.exceptions.PipelineException`. Removing the `src` from the import makes the test pass.


NOTE: Not including the `src` may cause issues with your IDE (it's confused about where the file is). This can be fixed in VS Code by adding the following line to your workspace settings:
```
    "python.analysis.extraPaths": ["src"],
```