### PR TITLE
Fix SAM Template and statemachine to allow deployment

### DIFF
--- a/src/timetables_etl.statemachine.json
+++ b/src/timetables_etl.statemachine.json
@@ -31,7 +31,8 @@
       },
       "ItemProcessor": {
         "ProcessorConfig": {
-          "Mode": "DISTRIBUTED"
+          "Mode": "DISTRIBUTED",
+          "ExecutionType": "STANDARD"
         },
         "StartAt": "basicFileValidation",
         "States": {
@@ -170,9 +171,9 @@
         "ParsedCause.$": "States.StringToJson($.error_info.Cause)"
       },
       "ResultPath": "$.parsed_error",
-      "Next": "exceptionHandler"
+      "Next": "mainExceptionHandler"
     },
-    "exceptionHandler": {
+    "mainExceptionHandler": {
       "Type": "Task",
       "Resource": "${ExceptionHandlerLambdaArn}",
       "Parameters": {

--- a/timetables-etl.yaml
+++ b/timetables-etl.yaml
@@ -16,12 +16,13 @@ Parameters:
   BoilerplateLambdaLayerArn:
     Type: String
   DynamoDBTableName:
-    Type: string
-    Default: !Sub "${ProjectName}-${Environment}-dynamodb-cache"
+    Type: String
+    Default: ""
   
 
 Conditions:
   IsNotLocal: !Not [!Equals [!Ref Environment, "local"]]
+  UseDefaultTableName: !Equals [!Ref DynamoDBTableName, ""]
 
 Globals:
   Function:
@@ -386,7 +387,10 @@ Resources:
   DynamoDB:
     Type: AWS::DynamoDB::Table
     Properties:
-      TableName: !Ref DynamoDBTableName
+      TableName: !If 
+        - UseDefaultTableName
+        - !Sub "${ProjectName}-${Environment}-dynamodb-cache"
+        - !Ref DynamoDBTableName
       AttributeDefinitions:
         - AttributeName: Key
           AttributeType: S


### PR DESCRIPTION
- We can't use !Sub for default values in AWS (localstack supports)
- Parameter String type has to have capitial S
- Add "ExecutionType": "STANDARD" to the statemachine so it's valid
- Rename parent exceptionHandler to mainExceptionHandler for now (it may need to be removed)