### PR TITLE
SqlDB Client: Fix not using iam_token 

### DIFF
--- a/src/boilerplate/common_layer/database/client.py
+++ b/src/boilerplate/common_layer/database/client.py
@@ -76,10 +76,19 @@ class PostgresSettings(BaseSettings):
         """
         if self.use_iam_auth and not iam_token:
             raise ValueError("IAM token required for non-local environment")
+        password = iam_token if self.use_iam_auth else self.POSTGRES_PASSWORD
+        logger.info(
+            "Constructing Connection URL",
+            username=self.POSTGRES_USER,
+            host=self.POSTGRES_HOST,
+            port=self.POSTGRES_PORT,
+            database=self.POSTGRES_DB,
+            ssl_mode=self.ssl_mode,
+        )
         url = MultiHostUrl.build(
             scheme="postgresql+psycopg2",
             username=self.POSTGRES_USER,
-            password=self.POSTGRES_PASSWORD,
+            password=password,
             host=self.POSTGRES_HOST,
             port=self.POSTGRES_PORT,
             path=self.POSTGRES_DB,


### PR DESCRIPTION
POSTGRES_PASSWORD was being used always instead of using the token returned by the IAM