### PR TITLE
Disable HTTPS_PROXY on standalone deployment

### DIFF
--- a/timetables-etl.yaml
+++ b/timetables-etl.yaml
@@ -72,7 +72,7 @@ Globals:
     Environment:
       Variables:
         HTTPS_PROXY: !If
-          - IsNotLocal
+          - IsUsingBodsInfra
           - !Sub 'http://squid.bodds.${Environment}:3128'
           - !Ref AWS::NoValue
         PROJECT_ENV: !Ref Environment


### PR DESCRIPTION
'http://squid.bodds.${Environment}:3128' is not available when deploying standalone causing the s3 downloads to fail