### PR TITLE
[No-Story] Fix use of "statuts" field in get_file_processing_error_code

### DIFF
--- a/src/boilerplate/common_layer/db/file_processing_result.py
+++ b/src/boilerplate/common_layer/db/file_processing_result.py
@@ -78,7 +78,7 @@ def get_record(db, class_name, filter_condition, error_message):
 
 def get_file_processing_error_code(db, status):
     class_name = db.classes.pipelines_pipelineerrorcode
-    filter_condition = class_name.status == status
+    filter_condition = class_name.error == status
     error_message = f"Processing error status {status} doesn't exist"
     return get_record(db, class_name, filter_condition, error_message)
 

--- a/tests/boilerplate/common_layer/db/test_file_processing_result.py
+++ b/tests/boilerplate/common_layer/db/test_file_processing_result.py
@@ -152,7 +152,7 @@ class TestFileProcessingResult(unittest.TestCase):
     def test_get_file_processing_error_code(self):
         error_status = "NO_DATA_FOUND"
         mock_db = MockedDB()
-        result_data = mock_db.classes.pipelines_pipelineerrorcode(status=error_status)
+        result_data = mock_db.classes.pipelines_pipelineerrorcode(error=error_status)
         mock_db.session.add(result_data)
         mock_db.session.commit()
 

--- a/tests/mock_db.py
+++ b/tests/mock_db.py
@@ -1,6 +1,17 @@
-from sqlalchemy import Column, Integer, String, Boolean, JSON, TIMESTAMP, Text, create_engine, event
-from sqlalchemy.orm import sessionmaker, declarative_base
 from types import SimpleNamespace
+
+from sqlalchemy import (
+    JSON,
+    TIMESTAMP,
+    Boolean,
+    Column,
+    Integer,
+    String,
+    Text,
+    create_engine,
+    event,
+)
+from sqlalchemy.orm import declarative_base, sessionmaker
 
 Base = declarative_base()
 
@@ -39,7 +50,7 @@ class pipeline_processing_step(Base):
 class pipeline_error_code(Base):
     __tablename__ = "pipelines_pipelineerrorcode"
     id = Column(Integer, primary_key=True)
-    status = Column(String(255))
+    error = Column(String(255))
 
 
 class organisation_datasetrevision(Base):


### PR DESCRIPTION
We're querying a field that doesn't exist `status`. The actual field is called `error`: https://github.com/department-for-transport-BODS/bods/blob/dev/transit_odp/pipelines/models.py#L264