### PR TITLE
Fix DB Viewer CSV Generated for service_id

### DIFF
--- a/tools/db_viewer/cli.py
+++ b/tools/db_viewer/cli.py
@@ -1,119 +1,171 @@
+"""
+Database View Tool to search by revision id or service ID
+"""
+
 from pathlib import Path
-from typer import Typer, Option, BadParameter
-from structlog.stdlib import get_logger
+
 from common_layer.database.models import NaptanStopPoint
+from common_layer.database.models.model_transmodel import (
+    TransmodelServicePattern,
+    TransmodelServicePatternStop,
+)
 from common_layer.database.repos import NaptanStopPointRepo
+from structlog.stdlib import get_logger
+from typer import BadParameter, Option, Typer
+
 from .config import DbConfig
 from .organisation import (
-    extract_dataset_revision,
     extract_dataset,
+    extract_dataset_revision,
     extract_organisation,
     extract_txc_attributes,
 )
 from .transmodel import (
-    extract_service_by_revision_id,
-    extract_service_by_id,
-    extract_servicepattern,
-    extract_servicepatternstop,
-    extract_stopactivity,
-    extract_service_service_patterns,
-    extract_servicepattern_localities,
-    extract_vehiclejourney,
     extract_bookingarrangements,
     extract_flexibleserviceoperationperiod,
-    extract_servicedorganisationvehiclejourney,
+    extract_service_by_id,
+    extract_service_service_patterns,
     extract_servicedorganisations,
+    extract_servicedorganisationvehiclejourney,
     extract_servicedorganisationworkingdays,
+    extract_servicepattern_localities,
+    extract_servicepatterns_by_ids,
+    extract_servicepatterns_by_revision_id,
+    extract_servicepatternstop,
+    extract_services_by_revision_id,
+    extract_stopactivity,
+    extract_vehiclejourney,
 )
-from .utils import (
-    get_db_instance,
-    SqlDB,
-    csv_extractor,
-)
+from .utils import SqlDB, csv_extractor, get_db_instance
 
 logger = get_logger()
 app = Typer()
 
 
 @csv_extractor()
-def extract_stoppoint(db: SqlDB, locality_ids: list[int]) -> list[NaptanStopPoint]:
+def extract_stoppoint(db: SqlDB, atco_codes: list[str]) -> list[NaptanStopPoint]:
     """
     Extract naptan stoppoint details from DB.
     """
     repo = NaptanStopPointRepo(db)
-    return repo.get_by_locality_ids(locality_ids)
+    stop_points, missing_stops = repo.get_by_atco_codes(atco_codes)
+    if missing_stops:
+        logger.warning("Some Stops were not found in DB", missing_stops=missing_stops)
+    return stop_points
 
 
-def process_data_extraction(
+def process_vehicle_journeys(
     db: SqlDB,
-    revision_id: int,
-    service_id: int | None = None,
-    output_path: Path | str | None = None,
+    service_pattern_stops: list[TransmodelServicePatternStop],
+    output_path: Path,
 ):
-    log = logger.bind(operation="batch_extraction")
-    log.info("Starting DB Data extraction and output to CSV")
-
-    if service_id:
-        result = extract_service_by_id(service_id)
-        revision_id = result.id
-
-    # Organisation related entity
-    result = extract_dataset_revision(db, revision_id, output_path=output_path)
-    dataset_id = result.dataset_id
-    result = extract_dataset(db, dataset_id, output_path=output_path)
-    organisation_id = result.organisation_id
-    extract_organisation(db, organisation_id, output_path=output_path)
-    extract_txc_attributes(db, revision_id, output_path=output_path)
-
-    # Transmodel related entities
-    results = extract_service_by_revision_id(db, revision_id, output_path=output_path)
-    service_ids = list(set([result.id for result in results]))
-
-    results = extract_servicepattern(db, revision_id, output_path=output_path)
-    service_pattern_ids = list(set([result.id for result in results]))
-
-    results = extract_servicepatternstop(
-        db, service_pattern_ids, output_path=output_path
-    )
-    stop_activity_ids = list(set([result.stop_activity_id for result in results]))
-    vehicle_journey_ids = list(set([result.vehicle_journey_id for result in results]))
+    """
+    Process Vehicle Journeys
+    """
+    vehicle_journey_ids = [
+        result.vehicle_journey_id for result in service_pattern_stops
+    ]
     extract_vehiclejourney(db, vehicle_journey_ids, output_path=output_path)
-
-    results = extract_servicepattern_localities(
-        db, service_pattern_ids, output_path=output_path
-    )
-
-    extract_stoppoint(
-        db,
-        list(set([result.locality_id for result in results])),
-        output_path=output_path,
-    )
-
-    extract_stopactivity(db, stop_activity_ids, output_path=output_path)
-
-    extract_service_service_patterns(db, service_ids, output_path=output_path)
-
-    extract_bookingarrangements(db, service_ids, output_path=output_path)
     extract_flexibleserviceoperationperiod(
         db, vehicle_journey_ids, output_path=output_path
     )
-    results = extract_servicedorganisationvehiclejourney(
+    serviced_org_vj = extract_servicedorganisationvehiclejourney(
         db, vehicle_journey_ids, output_path=output_path
     )
-
     extract_servicedorganisations(
         db,
-        list(set([it.serviced_organisation_id for it in results])),
+        [it.serviced_organisation_id for it in serviced_org_vj],
         output_path=output_path,
     )
     extract_servicedorganisationworkingdays(
         db,
-        list(set([it.id for it in results])),
+        [it.id for it in serviced_org_vj],
         output_path=output_path,
     )
 
 
-def validate_params(revision_id: int, service_id: int) -> None:
+def process_service_patterns(
+    db: SqlDB,
+    tm_service_patterns: list[TransmodelServicePattern],
+    output_path: Path,
+):
+    """
+    Items dependent on service patterns
+    """
+    service_pattern_ids = [result.id for result in tm_service_patterns]
+    service_pattern_stops = extract_servicepatternstop(
+        db, service_pattern_ids, output_path=output_path
+    )
+    extract_servicepattern_localities(db, service_pattern_ids, output_path=output_path)
+    extract_stoppoint(
+        db,
+        [result.atco_code for result in service_pattern_stops],
+        output_path=output_path,
+    )
+    stop_activity_ids = [result.stop_activity_id for result in service_pattern_stops]
+
+    extract_stopactivity(db, stop_activity_ids, output_path=output_path)
+    process_vehicle_journeys(db, service_pattern_stops, output_path)
+
+
+def process_from_service_id(
+    db: SqlDB,
+    service_id: int,
+    output_path: Path,
+):
+    """
+    Process data from Service ID
+    """
+    log = logger.bind(operation="batch_extraction")
+    service = extract_service_by_id(db, service_id, output_path=output_path)
+    if service is None:
+        log.error("Transmodel Service Not Found")
+        raise BadParameter("Transmodel Service was not found in Database")
+    extract_bookingarrangements(db, [service.id], output_path=output_path)
+    service_service_patterns = extract_service_service_patterns(
+        db, [service.id], output_path=output_path
+    )
+    service_pattern_ids = [sp.servicepattern_id for sp in service_service_patterns]
+    service_patterns = extract_servicepatterns_by_ids(db, service_pattern_ids)
+    process_service_patterns(db, service_patterns, output_path=output_path)
+
+
+def process_from_revision_id(
+    db: SqlDB,
+    revision_id: int,
+    output_path: Path,
+):
+    """
+    Extract Data from DB and Output to CSVs based on table name
+    """
+    log = logger.bind(operation="batch_extraction")
+    log.info("Starting DB Data extraction and output to CSV")
+
+    # Organisation related entity
+    dataset_revision = extract_dataset_revision(
+        db, revision_id, output_path=output_path
+    )
+    dataset = extract_dataset(db, dataset_revision.dataset_id, output_path=output_path)
+    if dataset:
+        extract_organisation(db, dataset.organisation_id, output_path=output_path)
+    extract_txc_attributes(db, revision_id, output_path=output_path)
+
+    # Transmodel related entities
+    tm_services = extract_services_by_revision_id(
+        db, revision_id, output_path=output_path
+    )
+    service_ids = [it.id for it in tm_services]
+
+    extract_service_service_patterns(db, service_ids, output_path=output_path)
+
+    extract_bookingarrangements(db, service_ids, output_path=output_path)
+    service_patterns = extract_servicepatterns_by_revision_id(
+        db, revision_id, output_path=output_path
+    )
+    process_service_patterns(db, service_patterns, output_path)
+
+
+def validate_params(revision_id: int | None, service_id: int | None) -> None:
     """
     Validate command line parameter
     """
@@ -127,11 +179,36 @@ def validate_params(revision_id: int, service_id: int) -> None:
         )
 
 
+def make_default_output_path(revision_id: int | None, service_id: int | None) -> Path:
+    """
+    Generate a default output path based on revision_id or service_id.
+    Creates directories if they don't exist.
+
+    Base path is ./data/db_viewer/ with either revision_id/<id> or service_id/<id>
+    """
+    base_path = Path("./data/db_viewer")
+
+    if not base_path.exists():
+        logger.info("Creating base directory structure", path=str(base_path))
+        base_path.mkdir(parents=True, exist_ok=True)
+
+    if revision_id is not None:
+        final_path = base_path / "revision_id" / str(revision_id)
+    else:
+        final_path = base_path / "service_id" / str(service_id)
+
+    if not final_path.exists():
+        logger.info("Creating output directory", path=str(final_path))
+        final_path.mkdir(parents=True, exist_ok=True)
+
+    return final_path
+
+
 @app.command()
 def main(
-    location: Path = Option(
+    output_path: Path | None = Option(
         None,
-        "--dir",
+        "--output-path",
         help="Paths to csv files",
     ),
     db_host: str = Option(
@@ -159,12 +236,12 @@ def main(
         "--db-port",
         help="Database port",
     ),
-    revision_id: int = Option(
+    revision_id: int | None = Option(
         None,
         "--revision-id",
         help="Dataset revision id",
     ),
-    service_id: int = Option(
+    service_id: int | None = Option(
         None,
         "--service-id",
         help="Service id",
@@ -174,13 +251,20 @@ def main(
     This tool queries a database then creates CSVs for ETL data for a
     specific revision id or service id
     """
+    validate_params(revision_id, service_id)
     config = DbConfig(
         host=db_host, port=db_port, user=db_user, password=db_password, database=db_name
     )
     db = get_db_instance(config)
-    process_data_extraction(
-        db=db, revision_id=revision_id, service_id=service_id, output_path=location
-    )
+    if output_path is None:
+        output_path = make_default_output_path(revision_id, service_id)
+    if revision_id:
+        process_from_revision_id(
+            db=db, revision_id=revision_id, output_path=output_path
+        )
+    if service_id:
+        process_from_service_id(db, service_id, output_path)
+    logger.info("Completed Processing", output_path=output_path)
 
 
 if __name__ == "__main__":

--- a/tools/db_viewer/organisation.py
+++ b/tools/db_viewer/organisation.py
@@ -1,4 +1,7 @@
-from structlog.stdlib import get_logger
+"""
+Organisation Data fetching
+"""
+
 from common_layer.database.models import (
     OrganisationDataset,
     OrganisationDatasetRevision,
@@ -8,14 +11,12 @@ from common_layer.database.models import (
 from common_layer.database.repos import (
     OrganisationDatasetRepo,
     OrganisationDatasetRevisionRepo,
-    OrganisationTXCFileAttributesRepo,
     OrganisationOrganisationRepo,
+    OrganisationTXCFileAttributesRepo,
 )
-from .utils import (
-    SqlDB,
-    csv_extractor,
-    DatasetRevisionNotFoundError,
-)
+from structlog.stdlib import get_logger
+
+from .utils import DatasetRevisionNotFoundError, SqlDB, csv_extractor
 
 logger = get_logger()
 
@@ -37,21 +38,23 @@ def extract_dataset_revision(
 
 
 @csv_extractor()
-def extract_dataset(db: SqlDB, dataset_id: int) -> OrganisationDataset:
+def extract_dataset(db: SqlDB, dataset_id: int) -> OrganisationDataset | None:
     """
-    Extract the dataset details from DB.
+    Extract the OrganisationDataset
     """
     repo = OrganisationDatasetRepo(db)
-    return repo.get_by_id(dataset_id)  # type: ignore
+    return repo.get_by_id(dataset_id)
 
 
 @csv_extractor()
-def extract_organisation(db: SqlDB, organisation_id: int) -> OrganisationOrganisation:
+def extract_organisation(
+    db: SqlDB, organisation_id: int
+) -> OrganisationOrganisation | None:
     """
     Extarct Organisation details from DB.
     """
     repo = OrganisationOrganisationRepo(db)
-    return repo.get_by_id(organisation_id)  # type: ignore
+    return repo.get_by_id(organisation_id)
 
 
 @csv_extractor()
@@ -62,4 +65,4 @@ def extract_txc_attributes(
     Extract TXC file attributes from DB.
     """
     repo = OrganisationTXCFileAttributesRepo(db)
-    return repo.get_by_revision_id(revision_id=revision_id)  # type: ignore
+    return repo.get_by_revision_id(revision_id=revision_id)

--- a/tools/db_viewer/transmodel.py
+++ b/tools/db_viewer/transmodel.py
@@ -1,66 +1,81 @@
-from structlog.stdlib import get_logger
 from common_layer.database.models import (
-    TransmodelService,
-    TransmodelServicePattern,
-    TransmodelServicePatternStop,
-    TransmodelStopActivity,
-    TransmodelServiceServicePattern,
-    TransmodelServicePatternLocality,
-    TransmodelServicePatternAdminAreas,
-    TransmodelTracksVehicleJourney,
     TransmodelBookingArrangements,
     TransmodelFlexibleServiceOperationPeriod,
-    TransmodelServicedOrganisationVehicleJourney,
+    TransmodelService,
     TransmodelServicedOrganisations,
+    TransmodelServicedOrganisationVehicleJourney,
     TransmodelServicedOrganisationWorkingDays,
+    TransmodelServicePattern,
+    TransmodelServicePatternAdminAreas,
+    TransmodelServicePatternLocality,
+    TransmodelServicePatternStop,
+    TransmodelServiceServicePattern,
+    TransmodelStopActivity,
+)
+from common_layer.database.models.model_transmodel_vehicle_journey import (
+    TransmodelVehicleJourney,
 )
 from common_layer.database.repos import (
-    TransmodelServiceRepo,
-    TransmodelServicePatternRepo,
-    TransmodelServicePatternStopRepo,
-    TransmodelStopActivityRepo,
-    TransmodelServiceServicePatternRepo,
-    TransmodelServicePatternLocalityRepo,
-    TransmodelServicePatternAdminAreaRepo,
-    TransmodelVehicleJourneyRepo,
     TransmodelBookingArrangementsRepo,
     TransmodelFlexibleServiceOperationPeriodRepo,
-    TransmodelServicedOrganisationVehicleJourneyRepo,
     TransmodelServicedOrganisationsRepo,
+    TransmodelServicedOrganisationVehicleJourneyRepo,
     TransmodelServicedOrganisationWorkingDaysRepo,
+    TransmodelServicePatternAdminAreaRepo,
+    TransmodelServicePatternLocalityRepo,
+    TransmodelServicePatternRepo,
+    TransmodelServicePatternStopRepo,
+    TransmodelServiceRepo,
+    TransmodelServiceServicePatternRepo,
+    TransmodelStopActivityRepo,
+    TransmodelVehicleJourneyRepo,
 )
-from .utils import (
-    SqlDB,
-    csv_extractor,
-)
+from structlog.stdlib import get_logger
+
+from .utils import SqlDB, csv_extractor
 
 logger = get_logger()
 
 
 @csv_extractor()
-def extract_service_by_revision_id(
+def extract_services_by_revision_id(
     db: SqlDB, revision_id: int
 ) -> list[TransmodelService]:
     """
-    Extract service details from DB.
+    Get the list of services associated to a revision_id
+    And output to csv
     """
     repo = TransmodelServiceRepo(db)
-    return repo.get_by_revision_id(revision_id)  # type: ignore
+    return repo.get_by_revision_id(revision_id)
 
 
 @csv_extractor()
-def extract_service_by_id(db: SqlDB, id: int) -> list[TransmodelService]:
+def extract_service_by_id(
+    db: SqlDB,
+    service_id: int,
+) -> TransmodelService | None:
     """
     Extract service details from DB.
     """
     repo = TransmodelServiceRepo(db)
-    return repo.get_by_id(id)  # type: ignore
+    return repo.get_by_id(service_id)
 
 
 @csv_extractor()
-def extract_servicepattern(
+def extract_servicepatterns_by_ids(
+    db: SqlDB, service_pattern_ids: list[int]
+) -> list[TransmodelServicePattern]:
+    """
+    Extract service pattern details from DB.
+    """
+    repo = TransmodelServicePatternRepo(db)
+    return repo.get_by_ids(service_pattern_ids)
+
+
+@csv_extractor()
+def extract_servicepatterns_by_revision_id(
     db: SqlDB, revision_id: int
-) -> tuple[list[int], list[TransmodelServicePattern]]:
+) -> list[TransmodelServicePattern]:
     """
     Extract service pattern details from DB.
     """
@@ -72,6 +87,9 @@ def extract_servicepattern(
 def extract_servicepatternstop(
     db: SqlDB, service_pattern_ids: list[int]
 ) -> list[TransmodelServicePatternStop]:
+    """
+    Extract the Service Pattern Stops by id
+    """
     repo = TransmodelServicePatternStopRepo(db)
     return repo.get_by_service_pattern_ids(service_pattern_ids)
 
@@ -106,7 +124,7 @@ def extract_servicepattern_localities(
     Extract service pattern localities
     """
     repo = TransmodelServicePatternLocalityRepo(db)
-    return repo.get_by_pattern_ids(servicepattern_ids)  # type: ignore
+    return repo.get_by_pattern_ids(servicepattern_ids)
 
 
 @csv_extractor()
@@ -123,12 +141,12 @@ def extract_servicepattern_admin_areas(
 @csv_extractor()
 def extract_vehiclejourney(
     db: SqlDB, vehicle_journey_ids: list[int]
-) -> list[TransmodelTracksVehicleJourney]:
+) -> list[TransmodelVehicleJourney]:
     """
     Extract vehicle journey details from DB.
     """
     repo = TransmodelVehicleJourneyRepo(db)
-    return repo.get_by_ids(vehicle_journey_ids)  # type: ignore
+    return repo.get_by_ids(vehicle_journey_ids)
 
 
 @csv_extractor()
@@ -146,7 +164,9 @@ def extract_bookingarrangements(
 def extract_flexibleserviceoperationperiod(
     db: SqlDB, vehicle_journey_ids: list[int]
 ) -> list[TransmodelFlexibleServiceOperationPeriod]:
-    """ """
+    """
+    Flexible Service Operation Period
+    """
     repo = TransmodelFlexibleServiceOperationPeriodRepo(db)
     return repo.get_by_vehicle_journey_ids(vehicle_journey_ids)
 


### PR DESCRIPTION
- Remove Dependency on revision_id when fetching by service_id
- Fetch Naptan stops by atco codes, not locality ID
- Use validate_params function
- Add default output path creation so it's not in generated in the root
  - Base path is ./data/db_viewer/ with either revision_id/<id> or service_id/<id>
- Fix Type errors and remove ignores on the types