### PR TITLE
Update Environment names for SqlDB Client

### DIFF
--- a/src/boilerplate/common_layer/database/client.py
+++ b/src/boilerplate/common_layer/database/client.py
@@ -29,9 +29,11 @@ class ProjectEnvironment(str, Enum):
     """Supported project environments."""
 
     LOCAL = "local"
-    DEVELOPMENT = "development"
+    DEVELOPMENT = "dev"
     STAGING = "staging"
-    PRODUCTION = "production"
+    TEST = "test"
+    UAT = "uat"
+    PRODUCTION = "prod"
     STANDALONE = "standalone"
 
 


### PR DESCRIPTION
- Update Dev, Staging Test, UAT for SqlDB Client
Fixes this error: 

- `Input should be 'local', 'development', 'staging', 'production' or 'standalone' [type=enum, input_value='dev', input_type=str]`