### PR TITLE
Fix PTI import

### DIFF
--- a/src/timetables_etl/pti/validators/factory.py
+++ b/src/timetables_etl/pti/validators/factory.py
@@ -1,8 +1,10 @@
 from pathlib import Path
 
 from common_layer.dynamodb.client import DynamoDB
-from pti.constants import PTI_SCHEMA_PATH
-from timetables_etl.pti.validators.xml_file import XmlFilePTIValidator
+
+from ..constants import PTI_SCHEMA_PATH
+from .xml_file import XmlFilePTIValidator
+
 
 def get_xml_file_pti_validator(dynamodb: DynamoDB) -> XmlFilePTIValidator:
     """


### PR DESCRIPTION
Using relative imports. `timetables_etl` isn't a valid module in the context of the lambda