### PR TITLE
Use datasetRevisionId as InitializePipeline input

### DIFF
--- a/src/timetables_etl.statemachine.json
+++ b/src/timetables_etl.statemachine.json
@@ -15,8 +15,7 @@
       "Parameters": {
         "Bucket.$": "$.detail.bucket.name",
         "ObjectKey.$": "$.detail.object.key",
-        "DatasetRevisionId.$": "$.detail.dataset_revision_id",
-        "DatasetType.$": "$.detail.dataset_type"
+        "DatasetRevisionId.$": "$.detail.datasetRevisionId"
       },
       "ResultPath": "$.initializePipeline",
       "Next": "ClamAvScanner",


### PR DESCRIPTION
- Update the state machine mapping to use `$.detail.datasetRevisionId` instead of `$.detail.dataset_revision_id`
- Fix pylint complaints in `src/timetables_etl/initialize_pipeline.py`