### PR TITLE
Fix FileLevelProcessing Map Input Vars

### DIFF
--- a/src/timetables_etl.statemachine.json
+++ b/src/timetables_etl.statemachine.json
@@ -40,9 +40,7 @@
       "Next": "FileLevelProcessing",
       "Catch": [
         {
-          "ErrorEquals": [
-            "States.ALL"
-          ],
+          "ErrorEquals": ["States.ALL"],
           "Next": "ParseError",
           "ResultPath": "$.error_info"
         }
@@ -54,7 +52,7 @@
         "DatasetRevisionId.$": "$.detail.datasetRevisionId",
         "Bucket.$": "$.detail.bucket.name",
         "Key.$": "$$.Map.Item.Value.Key",
-        "DatasetEtlTaskResultId.$": "$.detail.datasetEtlTaskResultId",
+        "DatasetEtlTaskResultId.$": "$.initializePipeline.DatasetEtlTaskResultId",
         "detail.$": "$.detail"
       },
       "ItemReader": {
@@ -81,9 +79,7 @@
             "Next": "SchemaCheck",
             "Catch": [
               {
-                "ErrorEquals": [
-                  "States.ALL"
-                ],
+                "ErrorEquals": ["States.ALL"],
                 "Next": "ExceptionHandler"
               }
             ]
@@ -98,9 +94,7 @@
             "Next": "PostSchemaCheck",
             "Catch": [
               {
-                "ErrorEquals": [
-                  "States.ALL"
-                ],
+                "ErrorEquals": ["States.ALL"],
                 "Next": "ExceptionHandler"
               }
             ]
@@ -115,9 +109,7 @@
             "Next": "FileAttributesEtl",
             "Catch": [
               {
-                "ErrorEquals": [
-                  "States.ALL"
-                ],
+                "ErrorEquals": ["States.ALL"],
                 "Next": "ExceptionHandler"
               }
             ]
@@ -132,9 +124,7 @@
             "Next": "PtiValidation",
             "Catch": [
               {
-                "ErrorEquals": [
-                  "States.ALL"
-                ],
+                "ErrorEquals": ["States.ALL"],
                 "Next": "ExceptionHandler"
               }
             ]
@@ -150,9 +140,7 @@
             "Next": "ETLProcess",
             "Catch": [
               {
-                "ErrorEquals": [
-                  "States.ALL"
-                ],
+                "ErrorEquals": ["States.ALL"],
                 "Next": "ExceptionHandler"
               }
             ]
@@ -170,9 +158,7 @@
             "Next": "Success",
             "Catch": [
               {
-                "ErrorEquals": [
-                  "States.ALL"
-                ],
+                "ErrorEquals": ["States.ALL"],
                 "Next": "ExceptionHandler"
               }
             ]


### PR DESCRIPTION
- The FileLevelProcessing Parameters only contained the DatasetRevisionId resulting in the first step failing