### PR TITLE
Use ConfigDict on all Pydantic Models instead of deprecated Config class

### DIFF
--- a/src/timetables_etl/etl/app/models.py
+++ b/src/timetables_etl/etl/app/models.py
@@ -15,12 +15,7 @@ class ETLInputData(BaseModel):
     Input data for the ETL Function
     """
 
-    class Config:
-        """
-        Allow us to map Bucket / Object Key
-        """
-
-        populate_by_name = True
+    model_config = ConfigDict(populate_by_name=True)
 
     task_id: int = Field(alias="DatasetEtlTaskResultId")
     file_attributes_id: int = Field(alias="fileAttributesId")

--- a/src/timetables_etl/file_attributes_etl/app/models.py
+++ b/src/timetables_etl/file_attributes_etl/app/models.py
@@ -2,7 +2,7 @@
 FileAttributesETL Lambda Pydantic Models or Dataclasses
 """
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class FileAttributesInputData(BaseModel):
@@ -10,12 +10,7 @@ class FileAttributesInputData(BaseModel):
     Input data for the ETL Function
     """
 
-    class Config:
-        """
-        Allow us to map Bucket / Object Key
-        """
-
-        populate_by_name = True
+    model_config = ConfigDict(populate_by_name=True)
 
     revision_id: int = Field(alias="DatasetRevisionId")
     s3_bucket_name: str = Field(alias="Bucket")

--- a/src/timetables_etl/schema_check/app/schema_check.py
+++ b/src/timetables_etl/schema_check/app/schema_check.py
@@ -16,7 +16,7 @@ from common_layer.db.file_processing_result import file_processing_result_to_db
 from common_layer.json_logging import configure_logging
 from common_layer.s3 import S3
 from lxml import etree
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from structlog.stdlib import get_logger
 
 tracer = Tracer()
@@ -28,12 +28,7 @@ class SchemaCheckInputData(BaseModel):
     Input data for the ETL Function
     """
 
-    class Config:
-        """
-        Allow us to map Bucket / Object Key
-        """
-
-        populate_by_name = True
+    model_config = ConfigDict(populate_by_name=True)
 
     revision_id: int = Field(alias="DatasetRevisionId")
     s3_bucket_name: str = Field(alias="Bucket")


### PR DESCRIPTION
In pydantic 2 the Config class was deprecated in favour of a `model_config` variable and a.typed ConfigDict with BaseModel configuration params