### PR TITLE
Fix input for ParentExceptionHandler

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: v1.0.35
+version: v1.0.36

--- a/src/timetables_etl.statemachine.json
+++ b/src/timetables_etl.statemachine.json
@@ -335,7 +335,7 @@
       "Arguments": {
         "Error": "{% $states.input.errorInfo.Error %}",
         "Cause": "{% $parse($states.input.errorInfo.Cause) %}",
-        "DatasetRevisionId": "{% $datasetRevisionId %}"
+        "DatasetEtlTaskResultId": "{% $DatasetEtlTaskResultId %}"
       }
     },
     "ParentFail": {


### PR DESCRIPTION
- Instead of `DatasetRevisionId` it requires `DatasetEtlTaskResultId` as an input