### PR TITLE
tools(txc-tools): Support tag search based on parent path and Zip it matching files

### DIFF
--- a/tools/txc_tools/cli.py
+++ b/tools/txc_tools/cli.py
@@ -65,6 +65,10 @@ def zip_tag_counter(
         str,
         typer.Argument(help="XML tag name to search for"),
     ],
+    zip_structure: Annotated[
+        str,
+        typer.Argument(help="Zip file structure(flat or nested)"),
+    ] = "flat",
     sub_zip_workers: Annotated[
         int,
         typer.Option(
@@ -87,6 +91,7 @@ def zip_tag_counter(
         mode=AnalysisMode.TAG,
         sub_zip_workers=sub_zip_workers,
         lookup_info=lookup_info,
+        zip_file_structure=zip_structure,
     )
 
 
@@ -126,8 +131,8 @@ def zip_txc_report(
     )
 
 
-@app.command(name="zip-tag-search-parent")
-def zip_tag_with_parent(
+@app.command(name="zip-tag-search")
+def zip_tag_with_parent(  # pylint: disable=too-many-arguments, too-many-positional-arguments
     zip_files: Annotated[
         list[Path],
         typer.Argument(
@@ -152,6 +157,10 @@ def zip_tag_with_parent(
             help='Identifier of tag(comma separated values eg. "id,ref,name"'
         ),
     ] = None,
+    zip_structure: Annotated[
+        str,
+        typer.Argument(help="Zip file structure(flat or nested)"),
+    ] = "flat",
     sub_zip_workers: Annotated[
         int,
         typer.Option(
@@ -165,8 +174,8 @@ def zip_tag_with_parent(
     ] = 4,
 ) -> None:
     """
-    Process multiple ZIP files in parallel, parsing TxC data from XML
-    and generating CSV reports.
+    Process multiple ZIP files in parallel, searching tag in XML with respect to
+    the path and generating CSV reports.
     """
     if id_elements is None:
         id_elements = "id,ref,name"
@@ -177,9 +186,10 @@ def zip_tag_with_parent(
     )
     execute_process(
         zip_files=zip_files,
-        mode=AnalysisMode.TAG_PARENT_CHILD,
+        mode=AnalysisMode.SEARCH,
         sub_zip_workers=sub_zip_workers,
         lookup_info=lookup_info,
+        zip_file_structure=zip_structure,
     )
 
 

--- a/tools/txc_tools/csv_output.py
+++ b/tools/txc_tools/csv_output.py
@@ -143,7 +143,7 @@ REPORTS: dict[AnalysisMode, Callable[..., None]] = {
     AnalysisMode.SIZE: generate_xml_info_report,
     AnalysisMode.TAG: generate_xml_info_report,
     AnalysisMode.TXC: generate_xml_txc_report,
-    AnalysisMode.TAG_PARENT_CHILD: generate_xml_tag_with_parent_report,
+    AnalysisMode.SEARCH: generate_xml_tag_with_parent_report,
 }
 
 

--- a/tools/txc_tools/models.py
+++ b/tools/txc_tools/models.py
@@ -124,7 +124,7 @@ class AnalysisMode(str, Enum):
     SIZE = "size"
     TAG = "tag"
     TXC = "txc"
-    TAG_PARENT_CHILD = "tag-parent-child"
+    SEARCH = "search"
 
 
 @dataclass

--- a/tools/txc_tools/xml_processor.py
+++ b/tools/txc_tools/xml_processor.py
@@ -153,7 +153,7 @@ XML_OBJECTS: dict[
     AnalysisMode.SIZE: get_tag_size_object,
     AnalysisMode.TAG: get_tag_size_object,
     AnalysisMode.TXC: get_txc_object,
-    AnalysisMode.TAG_PARENT_CHILD: get_elements_with_related_parent,
+    AnalysisMode.SEARCH: get_elements_with_related_parent,
 }
 
 

--- a/tools/txc_tools/zip_tag_match_xml.py
+++ b/tools/txc_tools/zip_tag_match_xml.py
@@ -1,0 +1,122 @@
+"""
+Module to support the functionality to zip the xml when tag matches.
+"""
+
+from collections import defaultdict
+from io import BytesIO
+from pathlib import Path
+from typing import Any
+import zipfile
+from pydantic import BaseModel
+from structlog.stdlib import get_logger
+
+from .models import AnalysisMode
+
+log = get_logger()
+
+
+def get_nested_zip_xml(
+    src_zip: zipfile.ZipFile, nested_zip_name: str, xml_files: set[str]
+):
+    """
+    Extracts and filters XML files from a nested ZIP
+    inside the main ZIP, returning a new ZIP in memory.
+    """
+    log.info("Extracting XML files from zip", name=nested_zip_name)
+    nested_zip_data = BytesIO(src_zip.read(nested_zip_name))
+    with zipfile.ZipFile(nested_zip_data, "r") as nested_src_zip:
+        for file_info in nested_src_zip.infolist():
+            if not file_info.is_dir() and file_info.filename in xml_files:
+                # Read the file from the original nested ZIP
+                with nested_src_zip.open(file_info.filename) as file:
+                    yield file_info.filename, file.read()
+
+
+def generate_zip_file_structure(**kwargs: dict[str, Any]) -> None:
+    """
+    Managing and generating a ZIP file structure.
+    """
+    valid_xmls = kwargs.get("valid_xmls", {})
+    file_info = kwargs.get("file_info")
+    file_structure = kwargs.get("file_structure")
+    src_zip = kwargs.get("src_zip")
+    dst_zip = kwargs.get("dst_zip")
+
+    assert isinstance(src_zip, zipfile.ZipFile)
+    assert isinstance(dst_zip, zipfile.ZipFile)
+    assert isinstance(file_info, zipfile.ZipInfo)
+
+    for zip_keys, xml_files in valid_xmls.items():
+        if zip_keys and zip_keys.endswith(file_info.filename):
+            if file_structure == "flat":
+                for file_name, xml_str in get_nested_zip_xml(
+                    src_zip, zip_keys, xml_files
+                ):
+                    dst_zip.writestr(file_name, xml_str)
+            else:
+                nested_zip_data = BytesIO()
+                with zipfile.ZipFile(
+                    nested_zip_data, "w", zipfile.ZIP_DEFLATED
+                ) as nested_dst_zip:
+                    for file_name, xml_str in get_nested_zip_xml(
+                        src_zip, zip_keys, xml_files
+                    ):
+                        nested_dst_zip.writestr(file_name, xml_str)
+
+                nested_zip_data.seek(0)
+                dst_zip.writestr(file_info.filename, nested_zip_data.read())
+
+
+def build_zip_with_matching_tag_xmls(
+    xml_datas: list[BaseModel],
+    mode: AnalysisMode,
+    source_zip: str,
+    target_zip: Path,
+    file_structure: str = "flat",
+) -> None:
+    """
+    Create zip file with xml have the tag
+    """
+    log.info("Building zip with xml matching tags", file_structure=file_structure)
+    if not mode in (AnalysisMode.TAG, AnalysisMode.SEARCH):
+        raise ValueError(f"Invalid tag name '{mode}' to zip")
+
+    filtered_items = (
+        [it for it in xml_datas if hasattr(it, "tag_count")]
+        if mode == AnalysisMode.TAG
+        else [it for it in xml_datas if getattr(it, "element_tag", None)]
+    )
+    valid_xmls = defaultdict(set)
+    for item in filtered_items:
+        parent_zip = getattr(item, "parent_zip", None)
+        file_path = getattr(item, "file_path", None)
+
+        if parent_zip and file_path:
+            valid_xmls[parent_zip].add(file_path)
+
+    if not valid_xmls:
+        log.info("No matching tag found, hence no zip file created")
+        return
+
+    with zipfile.ZipFile(source_zip, "r") as src_zip:
+        with zipfile.ZipFile(target_zip, "w", zipfile.ZIP_DEFLATED) as dst_zip:
+            for file_info in src_zip.infolist():
+                if file_info.is_dir():
+                    continue
+
+                if file_info.filename.endswith(".xml"):
+                    if any(it.endswith(file_info.filename) for it in valid_xmls[None]):
+                        with src_zip.open(file_info.filename) as file:
+                            dst_zip.writestr(file_info.filename, file.read())
+
+                elif file_info.filename.endswith(".zip"):
+                    file_details = {
+                        "valid_xmls": valid_xmls,
+                        "file_info": file_info,
+                        "file_structure": file_structure,
+                        "src_zip": src_zip,
+                        "dst_zip": dst_zip,
+                    }
+                    generate_zip_file_structure(**file_details)
+
+    log.info("Zip created with xml matching tags", xml_datas=target_zip)


### PR DESCRIPTION
 - TxC XML Tag can be searched using its parent path and tag matching files will be zipped  as below
    - `poetry run txc-tools zip-tag-search-parent 3_pti_pass_copy.zip Location AnnotatedStopPointRef flat`
 - Final result zip files and generated CSV files stored in 
    - `data/txc_tools/<folder-filename>`