### PR TITLE
feat(DQSTrigger): Added capability to trigger DQS state machine from ETL step function

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: v1.0.42
+version: v1.0.43

--- a/src/timetables_etl.statemachine.json
+++ b/src/timetables_etl.statemachine.json
@@ -309,7 +309,7 @@
     },
     "GenerateOutputZip": {
       "Type": "Task",
-      "Next": "Completed",
+      "Next": "DqsTrigger",
       "Resource": "${GenerateOutputZipLambdaArn}",
       "Arguments": {
         "MapRunArn": "{% $states.input.mapResults.MapRunArn %}",
@@ -327,6 +327,17 @@
           }
         }
       ]
+    },
+    "DqsTrigger": {
+      "Type": "Task",
+      "Next": "Completed",
+      "Resource": "arn:aws:states:::states:startExecution",
+      "Arguments": {
+        "StateMachineArn": "${DqsStateMachineArn}",
+        "Input": {
+          "DatasetRevisionId": "{% $datasetRevisionId %}"
+        }
+      }
     },
     "ParentExceptionHandler": {
       "Type": "Task",

--- a/timetables-etl.yaml
+++ b/timetables-etl.yaml
@@ -194,6 +194,8 @@ Resources:
         EtlProcessLambdaArn: !GetAtt EtlProcessLambda.Arn
         GenerateOutputZipLambdaArn: !GetAtt GenerateOutputZipLambda.Arn
         DefaultS3BucketName: !Sub 'bodds-${Environment}'
+        DqsStateMachineArn: !Sub 'arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:dqs-${Environment}-sm'
+
 
   ##########################################
   #### TIMETABLES STATE MACHINE TRIGGER ####
@@ -723,6 +725,16 @@ Resources:
                 Resource:
                   - !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/stepfunctions/${ProjectName}-${Environment}-${SubFunction}-sm:*'
                   - !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/stepfunctions/${ProjectName}-${Environment}-${SubFunction}-sm'
+        - PolicyName: StateMachineSfInvokePolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: states:StartExecution
+                Resource:
+                  - !Sub 'arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${ProjectName}-${Environment}-${SubFunction}-sm'
+                  - !Sub 'arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:dqs-${Environment}-sm'
+
   TimetablesStateMachineTriggerRole:
     Type: AWS::IAM::Role
     Condition: IsNotLocal


### PR DESCRIPTION
Added the capability to trigger the DQS state machine arn from the ETL serverless process.

- Added new Task - DQSTrigger to the statemachine definition file.
- Added corresponding definition substitution for the DQS state machine ARN
- Added corresponding policy for state machine execution
- JIRA ticket Id - BODS-7852