### PR TITLE
fix(DownloadDataset): Run DownloadDataset step after Pipeline Initialization step

### DIFF
--- a/src/timetables_etl.statemachine.json
+++ b/src/timetables_etl.statemachine.json
@@ -58,7 +58,8 @@
         "Url": "{% $url %}",
         "Bucket": "{% $s3Bucket %}",
         "DatasetType": "{% $datasetType %}",
-        "DatasetRevisionId": "{% $datasetRevisionId %}"
+        "DatasetRevisionId": "{% $datasetRevisionId %}",
+        "DatasetEtlTaskResultId": "{% $DatasetEtlTaskResultId %}"
       },
       "Assign": {
         "s3Bucket": "{% $states.result.s3.bucket %}",
@@ -82,7 +83,8 @@
         "Bucket": "{% $s3Bucket %}",
         "ObjectKey": "{% $s3Object %}",
         "DatasetRevisionId": "{% $datasetRevisionId %}",
-        "DatasetType": "{% $datasetType %}"
+        "DatasetType": "{% $datasetType %}",
+        "DatasetEtlTaskResultId": "{% $DatasetEtlTaskResultId %}"
       },
       "Assign": {
         "ExtractedSubFolder": "{% $states.result.body.generatedPrefix %}"


### PR DESCRIPTION
In this PR we move the DownloadDataset step so it happens after the pipeline has been initialized

**Context:**
If the user provides a URL instead of a direct file upload, we must first download the file. For larger files, this could take some time.

We'd like to give the user some feedback that the process is moving forward. To do so, we should update the `progress` field of the `DatasetEtlTaskResult`. Furthermore, if the dataset download fails we need to set an error status on the task result.

Therefore, the Initialize Pipeline step (which creates the DatasetEtlTaskResult) should run before the Dataset Download step.
