### PR TITLE
ci(lint-pr): Add release option for deployment branch merges

### DIFF
--- a/.github/workflows/lint-pr.yaml
+++ b/.github/workflows/lint-pr.yaml
@@ -34,6 +34,7 @@ jobs:
             chore
             revert
             tools
+            release
       - name: Comment on Incorrect PR Title
         uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728 #v2.9.1
         if: always() && (steps.lint_pr_title.outputs.error_message != null)


### PR DESCRIPTION
To allow us to tag merges into different branches add a `release` scope to the conventional Commits setup

Allowing us to do: `release(test): v1.2.3`
