### PR TITLE
tools(etl-state-machine): support the recent payload change for etl pipeline

### DIFF
--- a/tools/state_runner/models.py
+++ b/tools/state_runner/models.py
@@ -5,36 +5,34 @@ Model definition for state runner
 from pydantic import BaseModel
 
 
-class StateMachineInputS3Bucket(BaseModel):
-    """
-    Class to hold information about S3 bucket.
-    """
-
-    name: str
-
-
-class StateMachineInputS3ObjectKey(BaseModel):
+class StateMachineInputS3Object(BaseModel):
     """
     Class to hold information about S3 object key.
     """
 
-    key: str
+    object: str
 
 
-class StateMachineInputS3Details(BaseModel):
+class StateMachineS3Payload(BaseModel):
     """
-    Class to hold information about state machine payload details.
+    Class to hold information about state machine payload data from S3.
     """
 
-    bucket: StateMachineInputS3Bucket
-    object: StateMachineInputS3ObjectKey
+    inputDataSource: str
+    s3: StateMachineInputS3Object
     datasetRevisionId: str
     datasetType: str
+    overwriteInputDataset: bool = False
 
 
-class StateMachineInputPayload(BaseModel):
+class StateMachineURLPayload(BaseModel):
     """
-    Class to hold information about state machine payload events.
+    Class to hold information about state machine payload data from url.
     """
 
-    detail: StateMachineInputS3Details
+    inputDataSource: str
+    url: str
+    datasetRevisionId: str
+    datasetType: str
+    publishDatasetRevision: bool = False
+    overwriteInputDataset: bool = False

--- a/tools/state_runner/s3_uploads.py
+++ b/tools/state_runner/s3_uploads.py
@@ -3,7 +3,6 @@ Module to define the functionality to upload the file for state runner
 """
 
 import boto3
-import structlog
 from botocore.exceptions import (
     BotoCoreError,
     ClientError,
@@ -11,17 +10,8 @@ from botocore.exceptions import (
     ProfileNotFound,
 )
 from mypy_boto3_s3 import S3Client
-from structlog.stdlib import get_logger
 
-structlog.configure(
-    processors=[
-        structlog.processors.add_log_level,
-        structlog.processors.StackInfoRenderer(),
-        structlog.dev.ConsoleRenderer(),
-    ]
-)
-
-logger = get_logger()
+from .state_machines import logger
 
 
 class SessionCreationError(Exception):


### PR DESCRIPTION
Update etl-state-machine tool to handle the new parameters added to the state machine payload
 
CLI Options Added:
-  `data_source`
    - Mapped to `inputDataSource `key
    - Select between using an S3 or a URL to download from
-  `object_key`
    - Mapped to `s3.object`key
    - Dataset used from S3
-  `url`
    - Mapped to `url `key
    - Dataset downloaded from url, then used for timetable processing
-  `publish_data_revision`
    - Mapped to `publishDatasetRevision`key
    - Dataset published to view
-  `overwrite_dataset`
    - Mapped to `overwriteInputDataset`key
    - Dataset will be overwritten

