### PR TITLE
fix(IteratorLambda): Add missing Lambda Layer reference

### DIFF
--- a/periodic-tasks.yaml
+++ b/periodic-tasks.yaml
@@ -162,6 +162,8 @@ Resources:
       Handler: iterator.lambda_handler
       MemorySize: 128
       Role: !GetAtt IteratorLambdaExecutionRole.Arn
+      Layers:
+        - !Ref BoilerplateLambdaLayerArn
       LoggingConfig:
         LogGroup: !Ref IteratorLambdaLogGroup
 


### PR DESCRIPTION
The iterator lambda is failing because it is unable to import from the common layer.

Key Details:
- Add BoilerplayeLambdaLayer to IteratorLambda in periodic-tasks template