### PR TITLE
fix(DatadogServerlessExtensionlayer): Set DatadogServerless extensionLayerVersion to 68

### DIFF
--- a/timetables-etl.yaml
+++ b/timetables-etl.yaml
@@ -6,7 +6,7 @@ Transform:
       stackName: !Ref 'AWS::StackName'
       apiKeySecretArn: arn:aws:secretsmanager:eu-west-2:228266753808:secret:DD_API_KEY_ALL_ENV-WDa721
       pythonLayerVersion: 105
-      extensionLayerVersion: 69
+      extensionLayerVersion: 68
       site: datadoghq.eu
       service: !Sub '${ProjectName}-timetables-etl'
       env: !Ref Environment


### PR DESCRIPTION
We're seeing timeouts in all environments that we believe may be attributed to Datadog. We recently updated the layer version, so we'll try dropping it back down to version 68.