### PR TITLE
fix(InitializePipeline): Fix DynamoDB client instantiation in initialize pipeline

### DIFF
--- a/src/timetables_etl/initialize_pipeline/app/initialize_pipeline.py
+++ b/src/timetables_etl/initialize_pipeline/app/initialize_pipeline.py
@@ -18,7 +18,7 @@ from common_layer.database.repos import (
     ETLTaskResultRepo,
     OrganisationDatasetRevisionRepo,
 )
-from common_layer.dynamodb.client import DynamoDB
+from common_layer.dynamodb.client.cache import DynamoDBCache
 from common_layer.dynamodb.data_manager import FileProcessingDataManager
 from common_layer.enums import FeedStatus
 from common_layer.exceptions.pipeline_exceptions import PipelineException
@@ -81,7 +81,7 @@ def create_task_result(db: SqlDB, revision_id: int) -> DatasetETLTaskResult:
 
 
 def initialize_pipeline(
-    db: SqlDB, dynamodb: DynamoDB, event: InitializePipelineEvent
+    db: SqlDB, dynamodb: DynamoDBCache, event: InitializePipelineEvent
 ) -> DatasetETLTaskResult:
     """
     Initializes the pipeline for dataset processing.
@@ -119,7 +119,7 @@ def lambda_handler(event: dict[str, Any], context: LambdaContext) -> dict[str, A
     parsed_event = InitializePipelineEvent(**event)
 
     db = SqlDB()
-    dynamodb = DynamoDB()
+    dynamodb = DynamoDBCache()
     created_task_result = initialize_pipeline(db, dynamodb, parsed_event)
     metrics.add_metric(name="PipelineStarts", unit=MetricUnit.Count, value=1)
     ETLTaskResultRepo(db).update_progress(created_task_result.id, 10)

--- a/tests/timetables_etl/initialize_pipeline/test_initialize_pipeline.py
+++ b/tests/timetables_etl/initialize_pipeline/test_initialize_pipeline.py
@@ -135,7 +135,7 @@ def test_initialize_pipeline(mock_revision_repo):
     mock_task_repo.insert.return_value = task_result
 
     mock_dynamodb = create_autospec(
-        "common_layer.dynamodb.client.DynamoDB", instance=True
+        "common_layer.dynamodb.client.DynamoDBCache", instance=True
     )
     mock_data_manager = create_autospec(FileProcessingDataManager, instance=True)
     mock_data_manager.prefetch_and_cache_data.return_value = None


### PR DESCRIPTION
Initialize pipeline was incorrectly using the `DynamoDB` base class instead of the `DynamoDBCache` subclass. As a result, the TableName was not being set correctly (`DynamoDBCache` gets this from the `DYNAMODB_CACHE_TABLE_NAME` then sets it on the base client)

Key Details:
- Update initialize pipeline handler to use `DynamoDBCache` instead of `DynamoDB` base client