### PR TITLE
ci(lint-pr): Fix PR Tagging when component is capitalised

### DIFF
--- a/.github/workflows/lint-pr.yaml
+++ b/.github/workflows/lint-pr.yaml
@@ -70,7 +70,7 @@ jobs:
             core.info(`PR Title: ${pr.data.title}`);
 
             const title = pr.data.title;
-            const typeMatch = title.trim().match(/^([a-z]+)(?:\([a-z0-9-]*\))?:/);
+            const typeMatch = title.trim().match(/^([a-z]+)(?:\([a-zA-Z0-9-]*\))?:/);
             core.info(`Type Match: ${JSON.stringify(typeMatch)}`);
 
             const type = typeMatch?.[1];


### PR DESCRIPTION
- The regex is was not picking up the type of change when the first letter was capitalised in the subsection e.g. `fix(Something)`
- The change is going from `[a-z0-9-]` to  `[a-zA-Z0-9-]`
