### PR TITLE
release(dev): Bump version to v1.0.66

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: v1.0.64
+version: v1.0.66


### PR DESCRIPTION
Revert bumped version number down, resulting in failed deployment. Bumping it to the correct version to enable deployment.

