### PR TITLE
refactor(GtfsApiUrl): Updated template to use new GTFS API private link URL

### DIFF
--- a/periodic-tasks.yaml
+++ b/periodic-tasks.yaml
@@ -17,8 +17,6 @@ Parameters:
     Type: String
   CavlConsumerUrl:
     Type: String
-  GtfsApiBaseUrl:
-    Type: String
   RdsDbHostAddr:
     Type: String
     Default: ''
@@ -161,7 +159,8 @@ Resources:
       Environment:
         Variables:
           CAVL_CONSUMER_URL: !Ref CavlConsumerUrl
-          GTFS_API_BASE_URL: !Ref GtfsApiBaseUrl
+          GTFS_API_BASE_URL: !Ref AvlConsumerApiBaseUrl
+          GTFS_API_ACTIVE: 'True'
           AWS_SIRIVM_STORAGE_BUCKET_NAME: !If
             - IsNotLocal
             - !Sub '{{resolve:ssm:/bodds/${Environment}/s3/sirivm/name}}'

--- a/samconfig.yaml
+++ b/samconfig.yaml
@@ -97,4 +97,3 @@ prod:
         Environment='prod'
         AvlConsumerApiBaseUrl='https://obg8kxwhq9.execute-api.eu-west-2.amazonaws.com/v1'
         CavlConsumerUrl='https://api-consumer-cavl.itoworld.com'
-        GtfsApiBaseUrl='https://gtfs.prod-temp.integrated-data.dft-create-data.com'

--- a/src/periodic_tasks/create_gtfsrt_zip.py
+++ b/src/periodic_tasks/create_gtfsrt_zip.py
@@ -35,7 +35,7 @@ def lambda_handler(event: dict[str, Any], context: LambdaContext) -> dict[str, A
         db = SqlDB()
         archived_file_name = process_archive(db, gtfsrt_zip)
     except Exception as _err:
-        log.error("Archiving gtfstr data failed", exc_info=True)
+        log.error("Archiving gtfsrt data failed", exc_info=True)
         raise _err
     finally:
         clear_contextvars()

--- a/template.yaml
+++ b/template.yaml
@@ -15,9 +15,6 @@ Parameters:
   CavlConsumerUrl:
     Type: String
     Default: 'https://api-consumer-cavl-internal.dev.itoworld.com'
-  GtfsApiBaseUrl:
-    Type: String
-    Default: 'https://gtfs.test.integrated-data.dft-create-data.com'
   RdsDbHostAddr:
     Type: String
     Default: ''
@@ -50,7 +47,6 @@ Resources:
         ProjectName: !Ref ProjectName
         AvlConsumerApiBaseUrl: !Ref AvlConsumerApiBaseUrl
         CavlConsumerUrl: !Ref CavlConsumerUrl
-        GtfsApiBaseUrl: !Ref GtfsApiBaseUrl
         RdsDbHostAddr: !Ref RdsDbHostAddr
         RdsDbPort: !Ref RdsDbPort
         BoilerplateLambdaLayerArn: !Ref BoilerplateLambdaLayer


### PR DESCRIPTION
Go live against the new GTFS integrated data warehouse provided API is imminent. This changes switched existing connections to using the new feed, away from ITO.

Key Details:

- Update environment variables to use pre-existing value pointing to the new feed.
- Single typo against error output
