### PR TITLE
fix(ETLProcess): Use "" instead of None for missing TransmodelVehicleJourney.journey_code

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: v1.0.80
+version: v1.0.79


### PR DESCRIPTION
`Journey code` is stored in the DB as None and not empty string which the UI expects.

Key Details:
- Changing the missing `journey_code` from `None` to be empty string fixes the issue.

JIRA: https://kpmgengineering.atlassian.net/browse/BODS-8205
