### PR TITLE
fix(PublishRevision): BODS-8333 re-fetch revision as it's status is changed

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: v1.0.81
+version: v1.0.82

--- a/src/timetables_etl/generate_output_zip/app/db_operations.py
+++ b/src/timetables_etl/generate_output_zip/app/db_operations.py
@@ -156,10 +156,11 @@ def publish_revision(db: SqlDB, revision: OrganisationDatasetRevision):
         )
 
 
-def update_live_revision(db: SqlDB, revision: OrganisationDatasetRevision):
+def update_live_revision(db: SqlDB, revision_id: int):
     """
     Link published revision to a dataset
     """
+    revision = fetch_revision(db, revision_id)
     if revision.is_published is True and revision.status == FeedStatus.LIVE:
         repo = OrganisationDatasetRepo(db)
         repo.update_live_revision(revision.dataset_id, revision.id)

--- a/src/timetables_etl/generate_output_zip/app/generate_output_zip.py
+++ b/src/timetables_etl/generate_output_zip/app/generate_output_zip.py
@@ -166,7 +166,7 @@ def process_map_results(
 
     if input_data.publish_dataset_revision:
         publish_revision(db, revision)
-        update_live_revision(db, revision)
+        update_live_revision(db, revision.id)
 
     return processing_result
 


### PR DESCRIPTION
A revision is first published where it's `status`, `is_published` flag and `published_at` timestamp is updated. The next function to link it to the dataset should re-fetch the revision to get the latest revision object.


JIRA: https://kpmgengineering.atlassian.net/browse/BODS-8333
