### PR TITLE
fix(timetables-etl): Remove task data from ETL Process return

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: v1.0.90
+version: v1.0.91

--- a/src/timetables_etl/etl/app/etl_process.py
+++ b/src/timetables_etl/etl/app/etl_process.py
@@ -99,5 +99,4 @@ def lambda_handler(event: dict[str, Any], _context: LambdaContext) -> dict[str, 
         "status_code": 200,
         "message": "ETL Completed",
         "stats": stats.model_dump(),
-        "task_data": task_data.model_dump(),
     }


### PR DESCRIPTION
the TaskData variable was added to the return of the ETL Process but the issue is that it has items that aren't json serialisable resulting in task failure

