### PR TITLE
fix(DQS): Only trigger DQS if there are successful files to process

### DIFF
--- a/src/timetables_etl.statemachine.json
+++ b/src/timetables_etl.statemachine.json
@@ -403,7 +403,7 @@
         "PublishDatasetRevision": "{% $publishDatasetRevision %}",
         "OverwriteInputDataset": "{% $overwriteInputDataset %}"
       },
-      "Output": {
+      "Assign": {
         "finalResult": "{% $states.result %}"
       },
       "Catch": [
@@ -420,8 +420,7 @@
       "Type": "Choice",
       "Choices": [
         {
-          "Variable": "$.finalResult.body.successful_files",
-          "NumericGreaterThan": 0,
+          "Condition": "{% $finalResult.body.successful_files > 0 %}",
           "Next": "Trigger DQS State Machine"
         }
       ],


### PR DESCRIPTION
Adding a Choice state to skip DQS trigger if there are no successful files to process

Example: https://eu-west-2.console.aws.amazon.com/states/home?region=eu-west-2#/v2/executions/details/arn:aws:states:eu-west-2:228266753808:execution:bods-backend-temp-dev-tt-sm:test-no-dqs-trigger-if-no-successful-files-2

JIRA: https://kpmgengineering.atlassian.net/browse/BODS-8579
