### PR TITLE
ci(aws-auth): use shared-services account and assume role via role-chaining

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -195,3 +195,10 @@ jobs:
           repository: ${{ github.repository }}
           event-type: automated-deploy-dev
           client-payload: '{ "environment": "dev", "release_version": "${{ needs.validation.outputs.VERSION }}" }'
+
+      - name: trigger remote for dev2
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          repository: ${{ github.repository }}
+          event-type: automated-deploy-dev
+          client-payload: '{ "environment": "dev2", "release_version": "${{ needs.validation.outputs.VERSION }}" }'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,6 +46,7 @@ env:
     github.event_name == 'release' && github.event.release.tag_name || 'null' }}
   RC_SRC: ${{ vars.DEPLOYMENT_ARTEFACTS_S3_BUCKET }}
   BODS_DEFAULT_GITHUB_ACTIONS_ASSUME_ROLE_ARN: ${{ vars.BODS_DEFAULT_GITHUB_ACTIONS_ASSUME_ROLE_ARN }}
+  PROD_ASSUME_ROLE_ARN: ${{ vars.PROD_ASSUME_ROLE_ARN }}
 
 jobs:
   validation:
@@ -85,7 +86,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ env.AWS_REGION }}
-          role-to-assume: ${{ vars.ASSUME_ROLE_ARN }}
+          role-to-assume: ${{ env.PROD_ASSUME_ROLE_ARN }}
           role-session-name: ${{ vars.PROJECT_NAME }}-${{ env.RC_ENV }}-app-deploy-validation
           role-duration-seconds: 3600
           role-skip-session-tagging: true
@@ -128,7 +129,111 @@ jobs:
 
   deploy:
     runs-on: ubuntu-latest
+    environment:
+      ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.environment ||
+      github.event_name == 'release' && 'prod' ||
+      contains(fromJSON('["workflow_dispatch", "push"]'), github.event_name) && (
+      startsWith(github.ref, 'refs/tags/v') && 'prod' ||
+      github.ref_name == 'main' && 'uat' ||
+      github.ref_name == 'test' && 'test'
+      ) || 'dev' }}
     needs: validation
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: setup sam
+        uses: aws-actions/setup-sam@v2
+        with:
+          use-installer: true
+
+      # Configure AWS credentials against the BODS Shared-Services Account
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ env.BODS_DEFAULT_GITHUB_ACTIONS_ASSUME_ROLE_ARN }}
+          role-session-name: ${{ vars.PROJECT_NAME }}-${{ env.RC_ENV }}-app-deploy
+          role-duration-seconds: 3600
+          role-skip-session-tagging: true
+
+      # Assume a role into the BODS-PROD account
+      - name: Configure AWS Credentials in bodds-prod
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ vars.ASSUME_ROLE_ARN }}
+          role-session-name: ${{ vars.PROJECT_NAME }}-${{ env.RC_ENV }}-app-deploy
+          role-duration-seconds: 3600
+          role-skip-session-tagging: true
+          role-chaining: true
+
+      - name: retrieve code
+        env:
+          VERSION: ${{ needs.validation.outputs.VERSION }}
+        run: |
+          [[ $VERSION =~ ^v[0-9]+(\.[0-9]+){2}$ ]] && rc_path="bods-backend/releases/$VERSION" || rc_path="bods-backend/releases-dev/$VERSION"
+
+          aws s3 cp s3://$RC_SRC/$rc_path/packaged.yaml .
+          aws s3 cp s3://$RC_SRC/$rc_path/samconfig.yaml .
+          echo "[INFO] Application with version [${VERSION}] successfully downloaded"
+
+      - name: get stack name
+        id: get-stack
+        uses: mikefarah/yq@v4.45.1
+        with:
+          cmd: yq -r '."${{ env.RC_ENV }}".deploy.parameters.stack_name' samconfig.yaml
+
+      - name: deploy application for ${{ env.RC_ENV }}
+        env:
+          VERSION: ${{ needs.validation.outputs.VERSION }}
+          GIT_COMMIT: ${{ github.sha }}
+          GIT_REPO_URL: ${{ github.server_url }}/${{ github.repository }}.git
+        run: |
+          DYNAMIC_PARAMS="DDGitData='${GIT_COMMIT},${GIT_REPO_URL}' Version='${VERSION}'"
+
+          if ! yq eval ".\"${{ env.RC_ENV }}\".deploy.parameters.parameter_overrides" samconfig.yaml >/dev/null; then
+            echo "[WARN] parameter_overrides not found, initialising key"
+            yq eval -i ".\"${{ env.RC_ENV }}\".deploy.parameters.parameter_overrides = \"\"" samconfig.yaml
+          fi
+
+          EXISTING_PARAMS=$(yq eval ".\"${{ env.RC_ENV }}\".deploy.parameters.parameter_overrides" samconfig.yaml)
+          UPDATED_PARAMS="${EXISTING_PARAMS} ${DYNAMIC_PARAMS}"
+
+          yq eval -i ".\"${{ env.RC_ENV }}\".deploy.parameters.parameter_overrides = \"${UPDATED_PARAMS}\"" samconfig.yaml
+
+          sam deploy \
+            --template-file packaged.yaml \
+            --stack-name ${{ steps.get-stack.outputs.result }} \
+            --config-env $RC_ENV \
+            --region $AWS_REGION \
+            --no-confirm-changeset \
+            --no-fail-on-empty-changeset \
+            --s3-bucket $RC_SRC --s3-prefix bods-backend/deployments/$RC_ENV \
+            --tags "BuiltFrom=${VERSION} version=${VERSION} ProjectName=${{ vars.PROJECT_NAME }} Environment=${RC_ENV} AppManagerCFNStackKey=${{ steps.get-stack.outputs.result }}"
+          echo "[INFO] Application with version [${VERSION}] successfully deployed into ${RC_ENV^^}"
+
+      - name: update confluence page
+        uses: robsteel24/update-confluence@v1
+        with:
+          confluence_base_url: ${{ vars.CONFLUENCE_BASE_URL }}
+          confluence_page_id: ${{ vars.CONFLUENCE_PAGE_ID }}
+          atlassian_username: ${{ secrets.ATLASSIAN_USERNAME }}
+          atlassian_api_token: ${{ secrets.ATLASSIAN_API_TOKEN }}
+          component: 'bods-backend'
+          environment: ${{ env.RC_ENV }}
+          version: ${{ needs.validation.outputs.VERSION }}
+        continue-on-error: true
+
+  deploy-uat2:
+    runs-on: ubuntu-latest
+    environment:
+      ${{ github.ref_name == 'main' && 'uat2' }}
+    needs: validation
+    env:
+      RC_ENV: uat2
 
     permissions:
       id-token: write


### PR DESCRIPTION
- workflows authenticate against `shared-services` account
- then assumes a role via `role-chaining` to respective AWS account per environment

JIRA: https://kpmgengineering.atlassian.net/browse/BODS-8085
