### PR TITLE
fix(ETLProcess): Fix creation of Service Pattern Stops and Vehicle Journeys for Flexible Services

### DIFF
--- a/src/timetables_etl/etl/app/load/vehicle_journey/vehicle_journey.py
+++ b/src/timetables_etl/etl/app/load/vehicle_journey/vehicle_journey.py
@@ -155,6 +155,10 @@ def get_journey_pattern_lookup(
         if service.StandardService:
             for jp in service.StandardService.JourneyPattern:
                 jp_lookup[jp.id] = jp
+
+        if service.FlexibleService:
+            for fjp in service.FlexibleService.FlexibleJourneyPattern:
+                jp_lookup[fjp.id] = fjp
     return jp_lookup
 
 

--- a/tests/timetables_etl/etl/load/vehicle_journey/test_vehicle_journey.py
+++ b/tests/timetables_etl/etl/load/vehicle_journey/test_vehicle_journey.py
@@ -1,0 +1,54 @@
+from common_layer.xml.txc.models import (
+    TXCData,
+    TXCFlexibleJourneyPattern,
+    TXCFlexibleService,
+    TXCJourneyPattern,
+    TXCService,
+    TXCStandardService,
+)
+
+from tests.timetables_etl.factories.txc.factory_txc_data import (
+    TXCDataFactory,
+    TXCServiceFactory,
+    TXCStandardServiceFactory,
+)
+from timetables_etl.etl.app.load.vehicle_journey.vehicle_journey import (
+    get_journey_pattern_lookup,
+)
+
+
+def test_get_journey_pattern_lookup():
+    """
+    Test that JPs from both standard and flexible services are included in lookup
+    """
+
+    journey_pattern_1 = TXCJourneyPattern.model_construct(id="jp_1")
+    journey_pattern_2 = TXCJourneyPattern.model_construct(id="jp_2")
+
+    flexible_jp_1 = TXCFlexibleJourneyPattern.model_construct(id="jp_3")
+    flexible_jp_2 = TXCFlexibleJourneyPattern.model_construct(id="jp_4")
+
+    expected_result = {
+        "jp_1": journey_pattern_1,
+        "jp_2": journey_pattern_2,
+        "jp_3": flexible_jp_1,
+        "jp_4": flexible_jp_2,
+    }
+
+    standard_service = TXCStandardServiceFactory.create(
+        JourneyPattern=[journey_pattern_1, journey_pattern_2],
+    )
+    flexible_service = TXCFlexibleService.model_construct(
+        FlexibleJourneyPattern=[flexible_jp_1, flexible_jp_2],
+    )
+
+    txc_data = TXCDataFactory.create(
+        Services=[
+            TXCServiceFactory.create(StandardService=standard_service),
+            TXCServiceFactory.create(FlexibleService=flexible_service),
+        ]
+    )
+
+    lookup = get_journey_pattern_lookup(txc_data)
+
+    assert lookup == expected_result


### PR DESCRIPTION
Simple fix for the creation of service pattern stops and vehicle journeys when processing flexible services. The root cause was that the flexible journey patterns weren't being included in the journey pattern lookup dict, so `process_journey_pattern_vehicle_journeys` (which is responsible for creating both service pattern stops and vehicle journeys) was never being called

JIRA: https://kpmgengineering.atlassian.net/browse/BODS-8597
