### PR TITLE
fix(naptan-cache): handle null or empty naptan codes when inserting naptan data

### DIFF
--- a/src/periodic_tasks/naptan_cache_populator/app/data_loader/naptan_parser_xml.py
+++ b/src/periodic_tasks/naptan_cache_populator/app/data_loader/naptan_parser_xml.py
@@ -156,6 +156,9 @@ async def process_stop_points(
 
     try:
         async for stop_point in stop_points_stream:
+            if stop_point["NaptanCode"] is None or stop_point["NaptanCode"] == "":
+                del stop_point["NaptanCode"]
+
             current_batch.append(stop_point)
 
             if len(current_batch) >= transaction_size:


### PR DESCRIPTION
Fix for:

```
ClientError: An error occurred (ValidationException) when calling the BatchWriteItem operation: One or more parameter values were invalid: Type mismatch for Index Key NaptanCode Expected: S Actual: NULL IndexName: NaptanCodeIndex
```


JIRA: https://kpmgengineering.atlassian.net/browse/BODS-8028