### PR TITLE
fix(ETLProcess): Avoid incorrect deduplication of service pattern stops

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: v1.0.127
+version: v1.0.128

--- a/tests/factories/database/transmodel.py
+++ b/tests/factories/database/transmodel.py
@@ -9,6 +9,7 @@ import factory
 from common_layer.database.models import (
     TransmodelBookingArrangements,
     TransmodelService,
+    TransmodelServicePatternStop,
     TransmodelVehicleJourney,
 )
 
@@ -158,3 +159,21 @@ class TransmodelBookingArrangementsFactory(factory.Factory):
             web_address=web_address,
             service_id=service_id,
         )
+
+
+class TransmodelServicePatternStopFactory(factory.Factory):
+    """Factory for TransmodelServicePatternStop"""
+
+    class Meta:
+        model = TransmodelServicePatternStop
+
+    sequence_number = factory.Sequence(lambda n: n)
+    atco_code = factory.Faker("ATCO001")  # use a simple fake code
+    naptan_stop_id = None
+    service_pattern_id = 1
+    departure_time = None
+    is_timing_point = True
+    txc_common_name = None
+    vehicle_journey_id = None
+    stop_activity_id = None
+    auto_sequence_number = factory.SelfAttribute("sequence_number")

--- a/tests/timetables_etl/etl/transform/test_service_pattern_stops.py
+++ b/tests/timetables_etl/etl/transform/test_service_pattern_stops.py
@@ -1,13 +1,13 @@
 import pytest
 from common_layer.database.models import TransmodelServicePatternStop
 from common_layer.xml.txc.models import TXCJourneyPatternTimingLink
-from etl.app.transform.service_pattern_stops import is_duplicate_stop
 
 from tests.factories.database.transmodel import TransmodelServicePatternStopFactory
 from tests.timetables_etl.factories.txc import (
     TXCJourneyPatternStopUsageFactory,
     TXCJourneyPatternTimingLinkFactory,
 )
+from timetables_etl.etl.app.transform.service_pattern_stops import is_duplicate_stop
 
 
 @pytest.mark.parametrize(

--- a/tests/timetables_etl/etl/transform/test_service_pattern_stops.py
+++ b/tests/timetables_etl/etl/transform/test_service_pattern_stops.py
@@ -1,0 +1,78 @@
+import pytest
+from common_layer.database.models import TransmodelServicePatternStop
+from common_layer.xml.txc.models import TXCJourneyPatternTimingLink
+from etl.app.transform.service_pattern_stops import is_duplicate_stop
+
+from tests.factories.database.transmodel import TransmodelServicePatternStopFactory
+from tests.timetables_etl.factories.txc import (
+    TXCJourneyPatternStopUsageFactory,
+    TXCJourneyPatternTimingLinkFactory,
+)
+
+
+@pytest.mark.parametrize(
+    "current_stop_ref, current_sequence, previous_stop, previous_link, expected",
+    [
+        pytest.param(
+            "15800722",
+            0,
+            None,
+            None,
+            False,
+            id="No previous stop",
+        ),
+        pytest.param(
+            "15800722",
+            2,
+            TransmodelServicePatternStopFactory(
+                sequence_number=1, atco_code="15800722"
+            ),
+            TXCJourneyPatternTimingLinkFactory(
+                From=TXCJourneyPatternStopUsageFactory(StopPointRef="15800722"),
+                To=TXCJourneyPatternStopUsageFactory(StopPointRef="15800722"),
+            ),
+            False,
+            id="Previous link has the same From/To",
+        ),
+        pytest.param(
+            "15800722",
+            2,
+            TransmodelServicePatternStopFactory(
+                sequence_number=1, atco_code="15800722"
+            ),
+            TXCJourneyPatternTimingLinkFactory(
+                From=TXCJourneyPatternStopUsageFactory(StopPointRef="15800721"),
+                To=TXCJourneyPatternStopUsageFactory(StopPointRef="15800722"),
+            ),
+            True,
+            id="Is duplicate stop",
+        ),
+        pytest.param(
+            "15800723",
+            2,
+            TransmodelServicePatternStopFactory(
+                sequence_number=1, atco_code="15800722"
+            ),
+            TXCJourneyPatternTimingLinkFactory(
+                From=TXCJourneyPatternStopUsageFactory(StopPointRef="15800722"),
+                To=TXCJourneyPatternStopUsageFactory(StopPointRef="15800723"),
+            ),
+            False,
+            id="Is not duplicate (previous_stop.atco_code != current_stop_ref)",
+        ),
+    ],
+)
+def test_is_duplicate_stop(
+    current_stop_ref: str,
+    current_sequence: int,
+    previous_stop: TransmodelServicePatternStop | None,
+    previous_link: TXCJourneyPatternTimingLink | None,
+    expected: bool,
+):
+    result = is_duplicate_stop(
+        current_stop_ref=current_stop_ref,
+        current_sequence=current_sequence,
+        previous_stop=previous_stop,
+        previous_link=previous_link,
+    )
+    assert result == expected


### PR DESCRIPTION
Key Details:
- We encountered an edge case where a timing link describes a bus that picks up and drops off at the same stop. This was resulting in the next stop being incorrectly omitted by our deduplication logic. 
- In this PR we add an additional check to the `is_duplicate_stop` function to handle this edge case

JIRA: https://kpmgengineering.atlassian.net/browse/BODS-8631