### PR TITLE
fix(ExceptionHandler): Exception handling improvements

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: v1.0.133
+version: v1.0.134

--- a/src/timetables_etl.statemachine.json
+++ b/src/timetables_etl.statemachine.json
@@ -636,8 +636,8 @@
           "Next": "Parent Exception Handler",
           "Output": {
             "errorInfo": {
-              "Error": "$.error",
-              "Cause": "$.cause"
+              "Error": "{% $states.errorOutput.error %}",
+              "Cause": "{% $states.errorOutput.error %}"
             },
             "stepName": "Trigger DQS State Machine",
             "failDatasetRevision": false,

--- a/src/timetables_etl.statemachine.json
+++ b/src/timetables_etl.statemachine.json
@@ -418,7 +418,7 @@
             "Arguments": {
               "Error": "{% $states.input.errorInfo.Error %}",
               "Cause": "{% $states.input.errorInfo.Cause %}",
-              "DatasetEtlTaskResultId": "{% $datasetETLTaskResultId %}",
+              "DatasetEtlTaskResultId": "{% $states.input.mapDatasetEtlTaskResultId %}",
               "StepName": "{% $states.input.stepName %}",
               "FailDatasetRevision": false,
               "FailDatasetETLTaskResult": false
@@ -571,7 +571,7 @@
             "Arguments": {
               "Error": "{% $states.input.errorInfo.Error %}",
               "Cause": "{% $states.input.errorInfo.Cause %}",
-              "DatasetEtlTaskResultId": "{% $datasetETLTaskResultId %}",
+              "DatasetEtlTaskResultId": "{% $datasetEtlTaskResultId %}",
               "StepName": "{% $states.input.stepName %}",
               "FailDatasetRevision": false,
               "FailDatasetETLTaskResult": false

--- a/src/timetables_etl.statemachine.json
+++ b/src/timetables_etl.statemachine.json
@@ -636,8 +636,8 @@
           "Next": "Parent Exception Handler",
           "Output": {
             "errorInfo": {
-              "Error": "{% $.error %}",
-              "Cause": "{% $.cause %}"
+              "Error": "$.error",
+              "Cause": "$.cause"
             },
             "stepName": "{% $states.context.State.Name %}",
             "failDatasetRevision": false,

--- a/src/timetables_etl.statemachine.json
+++ b/src/timetables_etl.statemachine.json
@@ -105,7 +105,7 @@
           "Next": "Parent Exception Handler",
           "Output": {
             "errorInfo": "$.error",
-            "stepName": "{% $states.context.State.Name %}"
+            "stepName": "Acquire Lock"
           }
         }
       ],
@@ -203,7 +203,7 @@
           "Next": "Parent Exception Handler",
           "Output": {
             "errorInfo": "{% $states.errorOutput %}",
-            "stepName": "{% $states.context.State.Name %}"
+            "stepName": "Initialize Pipeline"
           }
         }
       ]
@@ -245,7 +245,7 @@
           "Next": "Parent Exception Handler",
           "Output": {
             "errorInfo": "{% $states.errorOutput %}",
-            "stepName": "{% $states.context.State.Name %}"
+            "stepName": "Download Dataset"
           }
         }
       ]
@@ -272,7 +272,7 @@
           "Next": "Parent Exception Handler",
           "Output": {
             "errorInfo": "{% $states.errorOutput %}",
-            "stepName": "{% $states.context.State.Name %}"
+            "stepName": "ClamAV and Extraction"
           }
         }
       ]
@@ -453,7 +453,7 @@
           "Next": "Parent Exception Handler",
           "Output": {
             "errorInfo": "{% $states.errorOutput %}",
-            "stepName": "{% $states.context.State.Name %}"
+            "stepName": "Collate Files"
           }
         }
       ]
@@ -603,7 +603,7 @@
           "Next": "Parent Exception Handler",
           "Output": {
             "errorInfo": "{% $states.errorOutput %}",
-            "stepName": "{% $states.context.State.Name %}"
+            "stepName": "Generate Output Zip and Update Status"
           }
         }
       ]
@@ -639,7 +639,7 @@
               "Error": "$.error",
               "Cause": "$.cause"
             },
-            "stepName": "{% $states.context.State.Name %}",
+            "stepName": "Trigger DQS State Machine",
             "failDatasetRevision": false,
             "failDatasetETLTaskResult": true
           }
@@ -698,7 +698,7 @@
           "Next": "Parent Exception Handler",
           "Output": {
             "errorInfo": "$.error",
-            "stepName": "{% $states.context.State.Name %}"
+            "stepName": "Release Lock"
           }
         }
       ],

--- a/src/timetables_etl.statemachine.json
+++ b/src/timetables_etl.statemachine.json
@@ -331,7 +331,8 @@
                 ],
                 "Next": "Validation Exception Handler",
                 "Output": {
-                  "errorInfo": "{% $states.errorOutput %}"
+                  "errorInfo": "{% $states.errorOutput %}",
+                  "stepName": "File Validation"
                 }
               }
             ]
@@ -355,7 +356,8 @@
                 ],
                 "Next": "Validation Exception Handler",
                 "Output": {
-                  "errorInfo": "{% $states.errorOutput %}"
+                  "errorInfo": "{% $states.errorOutput %}",
+                  "stepName": "XSD Schema Check"
                 }
               }
             ]
@@ -379,7 +381,8 @@
                 ],
                 "Next": "Validation Exception Handler",
                 "Output": {
-                  "errorInfo": "{% $states.errorOutput %}"
+                  "errorInfo": "{% $states.errorOutput %}",
+                  "stepName": "Post Schema Check"
                 }
               }
             ]
@@ -403,7 +406,8 @@
                 ],
                 "Next": "Validation Exception Handler",
                 "Output": {
-                  "errorInfo": "{% $states.errorOutput %}"
+                  "errorInfo": "{% $states.errorOutput %}",
+                  "stepName": "FileAttributes ETL"
                 }
               }
             ]
@@ -529,7 +533,8 @@
                 ],
                 "Next": "ETL Exception Handler",
                 "Output": {
-                  "errorInfo": "{% $states.errorOutput %}"
+                  "errorInfo": "{% $states.errorOutput %}",
+                  "stepName": "PTI Validation"
                 }
               }
             ]
@@ -556,7 +561,8 @@
                 ],
                 "Next": "ETL Exception Handler",
                 "Output": {
-                  "errorInfo": "{% $states.errorOutput %}"
+                  "errorInfo": "{% $states.errorOutput %}",
+                  "stepName": "Timetables ETL"
                 }
               }
             ]

--- a/src/timetables_etl.statemachine.json
+++ b/src/timetables_etl.statemachine.json
@@ -636,8 +636,8 @@
           "Next": "Parent Exception Handler",
           "Output": {
             "errorInfo": {
-              "Error": "{% $states.errorOutput.error %}",
-              "Cause": "{% $states.errorOutput.cause %}"
+              "Error": "{% $.error %}",
+              "Cause": "{% $.cause %}"
             },
             "stepName": "{% $states.context.State.Name %}",
             "failDatasetRevision": false,

--- a/src/timetables_etl.statemachine.json
+++ b/src/timetables_etl.statemachine.json
@@ -623,7 +623,7 @@
       "Next": "Release Lock",
       "Resource": "arn:aws:states:::states:startExecution",
       "Arguments": {
-        "StateMachineArn": "${DqsStateMachineArn}",
+        "StateMachineArn": "invalid-arn",
         "Input": {
           "DatasetRevisionId": "{% $datasetRevisionId %}"
         }

--- a/src/timetables_etl.statemachine.json
+++ b/src/timetables_etl.statemachine.json
@@ -412,8 +412,17 @@
             "Type": "Succeed"
           },
           "Validation Exception Handler": {
-            "Type": "Pass",
-            "Next": "Validation Failed"
+            "Type": "Task",
+            "Next": "Validation Failed",
+            "Resource": "${ExceptionHandlerLambdaArn}",
+            "Arguments": {
+              "Error": "{% $states.input.errorInfo.Error %}",
+              "Cause": "{% $states.input.errorInfo.Cause %}",
+              "DatasetEtlTaskResultId": "{% $datasetETLTaskResultId %}",
+              "StepName": "{% $states.input.stepName %}",
+              "FailDatasetRevision": false,
+              "FailDatasetETLTaskResult": false
+            }
           },
           "Validation Failed": {
             "Type": "Fail",
@@ -556,8 +565,17 @@
             "Type": "Succeed"
           },
           "ETL Exception Handler": {
-            "Type": "Pass",
-            "Next": "PTI and ETL Failed"
+            "Type": "Task",
+            "Next": "PTI and ETL Failed",
+            "Resource": "${ExceptionHandlerLambdaArn}",
+            "Arguments": {
+              "Error": "{% $states.input.errorInfo.Error %}",
+              "Cause": "{% $states.input.errorInfo.Cause %}",
+              "DatasetEtlTaskResultId": "{% $datasetETLTaskResultId %}",
+              "StepName": "{% $states.input.stepName %}",
+              "FailDatasetRevision": false,
+              "FailDatasetETLTaskResult": false
+            }
           },
           "PTI and ETL Failed": {
             "Type": "Fail"

--- a/src/timetables_etl.statemachine.json
+++ b/src/timetables_etl.statemachine.json
@@ -623,7 +623,7 @@
       "Next": "Release Lock",
       "Resource": "arn:aws:states:::states:startExecution",
       "Arguments": {
-        "StateMachineArn": "invalid-arn",
+        "StateMachineArn": "${DqsStateMachineArn}",
         "Input": {
           "DatasetRevisionId": "{% $datasetRevisionId %}"
         }

--- a/src/timetables_etl.statemachine.json
+++ b/src/timetables_etl.statemachine.json
@@ -104,7 +104,8 @@
           ],
           "Next": "Parent Exception Handler",
           "Output": {
-            "errorInfo": "$.error"
+            "errorInfo": "$.error",
+            "stepName": "{% $states.context.State.Name %}"
           }
         }
       ],
@@ -201,7 +202,8 @@
           ],
           "Next": "Parent Exception Handler",
           "Output": {
-            "errorInfo": "{% $states.errorOutput %}"
+            "errorInfo": "{% $states.errorOutput %}",
+            "stepName": "{% $states.context.State.Name %}"
           }
         }
       ]
@@ -242,7 +244,8 @@
           ],
           "Next": "Parent Exception Handler",
           "Output": {
-            "errorInfo": "{% $states.errorOutput %}"
+            "errorInfo": "{% $states.errorOutput %}",
+            "stepName": "{% $states.context.State.Name %}"
           }
         }
       ]
@@ -268,7 +271,8 @@
           ],
           "Next": "Parent Exception Handler",
           "Output": {
-            "errorInfo": "{% $states.errorOutput %}"
+            "errorInfo": "{% $states.errorOutput %}",
+            "stepName": "{% $states.context.State.Name %}"
           }
         }
       ]
@@ -448,7 +452,8 @@
           ],
           "Next": "Parent Exception Handler",
           "Output": {
-            "errorInfo": "{% $states.errorOutput %}"
+            "errorInfo": "{% $states.errorOutput %}",
+            "stepName": "{% $states.context.State.Name %}"
           }
         }
       ]
@@ -597,7 +602,8 @@
           ],
           "Next": "Parent Exception Handler",
           "Output": {
-            "errorInfo": "{% $states.errorOutput %}"
+            "errorInfo": "{% $states.errorOutput %}",
+            "stepName": "{% $states.context.State.Name %}"
           }
         }
       ]
@@ -632,7 +638,10 @@
             "errorInfo": {
               "Error": "{% $states.errorOutput.error %}",
               "Cause": "{% $states.errorOutput.cause %}"
-            }
+            },
+            "stepName": "{% $states.context.State.Name %}",
+            "failDatasetRevision": false,
+            "failDatasetETLTaskResult": true
           }
         }
       ]
@@ -688,7 +697,8 @@
           ],
           "Next": "Parent Exception Handler",
           "Output": {
-            "errorInfo": "$.error"
+            "errorInfo": "$.error",
+            "stepName": "{% $states.context.State.Name %}"
           }
         }
       ],
@@ -701,7 +711,10 @@
       "Arguments": {
         "Error": "{% $states.input.errorInfo.Error %}",
         "Cause": "{% $states.input.errorInfo.Cause %}",
-        "DatasetEtlTaskResultId": "{% $datasetETLTaskResultId %}"
+        "DatasetEtlTaskResultId": "{% $datasetETLTaskResultId %}",
+        "StepName": "{% $exists(states.input.stepName) ? $states.input.stepName : null %}",
+        "FailDatasetRevision": "{% $exists(states.input.failDatasetRevision) ? $states.input.failDatasetRevision : null %}",
+        "FailDatasetETLTaskResult": "{% $exists(states.input.failDatasetETLTaskResult) ? $states.input.failDatasetETLTaskResult : null %}"
       }
     },
     "Release Lock Exception Handler": {

--- a/src/timetables_etl.statemachine.json
+++ b/src/timetables_etl.statemachine.json
@@ -712,9 +712,9 @@
         "Error": "{% $states.input.errorInfo.Error %}",
         "Cause": "{% $states.input.errorInfo.Cause %}",
         "DatasetEtlTaskResultId": "{% $datasetETLTaskResultId %}",
-        "StepName": "{% $exists(states.input.stepName) ? $states.input.stepName : null %}",
-        "FailDatasetRevision": "{% $exists(states.input.failDatasetRevision) ? $states.input.failDatasetRevision : null %}",
-        "FailDatasetETLTaskResult": "{% $exists(states.input.failDatasetETLTaskResult) ? $states.input.failDatasetETLTaskResult : null %}"
+        "StepName": "{% $states.input.stepName %}",
+        "FailDatasetRevision": "{% $states.input.failDatasetRevision %}",
+        "FailDatasetETLTaskResult": "{% $states.input.failDatasetETLTaskResult %}"
       }
     },
     "Release Lock Exception Handler": {

--- a/src/timetables_etl.statemachine.json
+++ b/src/timetables_etl.statemachine.json
@@ -635,10 +635,7 @@
           ],
           "Next": "Parent Exception Handler",
           "Output": {
-            "errorInfo": {
-              "Error": "{% $states.errorOutput.error %}",
-              "Cause": "{% $states.errorOutput.error %}"
-            },
+            "errorInfo": "{% $states.errorOutput }",
             "stepName": "Trigger DQS State Machine",
             "failDatasetRevision": false,
             "failDatasetETLTaskResult": true

--- a/src/timetables_etl.statemachine.json
+++ b/src/timetables_etl.statemachine.json
@@ -621,7 +621,21 @@
         "Input": {
           "DatasetRevisionId": "{% $datasetRevisionId %}"
         }
-      }
+      },
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Next": "Parent Exception Handler",
+          "Output": {
+            "errorInfo": {
+              "Error": "{% $states.errorOutput.error %}",
+              "Cause": "{% $states.errorOutput.cause %}"
+            }
+          }
+        }
+      ]
     },
     "Release Lock": {
       "Type": "Task",

--- a/src/timetables_etl.statemachine.json
+++ b/src/timetables_etl.statemachine.json
@@ -635,7 +635,7 @@
           ],
           "Next": "Parent Exception Handler",
           "Output": {
-            "errorInfo": "{% $states.errorOutput }",
+            "errorInfo": "{% $states.errorOutput %}",
             "stepName": "Trigger DQS State Machine",
             "failDatasetRevision": false,
             "failDatasetETLTaskResult": true

--- a/src/timetables_etl/exception_handler/app/exception_handler.py
+++ b/src/timetables_etl/exception_handler/app/exception_handler.py
@@ -30,7 +30,7 @@ def handle_error(db: SqlDB, event_data: ExceptionHandlerInputData):
     if event_data.fail_dataset_etl_task_result:
         task_result_repo.mark_error(
             task_id=event_data.dataset_etl_task_result_id,
-            task_name="Exception Handler Does not Know Failed Task Name",
+            task_name=event_data.step_name,
             error_code=event_data.cause.error_code,
             additional_info=event_data.cause.extracted_message,
         )

--- a/src/timetables_etl/exception_handler/app/exception_handler.py
+++ b/src/timetables_etl/exception_handler/app/exception_handler.py
@@ -52,7 +52,7 @@ def lambda_handler(event: dict[str, Any], context: LambdaContext) -> dict[str, A
     parsed_event = ExceptionHandlerInputData(**event)
     log.error(
         "Step Failed",
-        parsed_event.cause.error_message,
+        error_message=parsed_event.cause.error_message,
         error_details=parsed_event.cause,
         step_name=parsed_event.step_name,
     )

--- a/src/timetables_etl/exception_handler/app/exception_handler.py
+++ b/src/timetables_etl/exception_handler/app/exception_handler.py
@@ -54,7 +54,6 @@ def lambda_handler(event: dict[str, Any], context: LambdaContext) -> dict[str, A
         "Step Failed",
         error_message=parsed_event.cause.error_message,
         error_details=parsed_event.cause,
-        step_name=parsed_event.step_name,
     )
 
     db = SqlDB()

--- a/src/timetables_etl/exception_handler/app/exception_handler.py
+++ b/src/timetables_etl/exception_handler/app/exception_handler.py
@@ -7,7 +7,6 @@ from typing import Any
 import common_layer.aws.datadog.tracing  # type: ignore # pylint: disable=unused-import
 from aws_lambda_powertools.utilities.typing import LambdaContext
 from common_layer.database.client import SqlDB
-from common_layer.database.models import OrganisationDatasetRevision
 from common_layer.database.repos import (
     ETLTaskResultRepo,
     OrganisationDatasetRevisionRepo,
@@ -21,28 +20,26 @@ from .models import ExceptionHandlerInputData
 log = get_logger()
 
 
-def handle_error(
-    db: SqlDB, event_data: ExceptionHandlerInputData
-) -> OrganisationDatasetRevision:
+def handle_error(db: SqlDB, event_data: ExceptionHandlerInputData):
     """
     Core error handling logic
     """
     task_result_repo = ETLTaskResultRepo(db)
     task_result = task_result_repo.require_by_id(event_data.dataset_etl_task_result_id)
 
-    revision_repo = OrganisationDatasetRevisionRepo(db)
-    revision = revision_repo.require_by_id(task_result.revision_id)
+    if event_data.fail_dataset_etl_task_result:
+        task_result_repo.mark_error(
+            task_id=event_data.dataset_etl_task_result_id,
+            task_name="Exception Handler Does not Know Failed Task Name",
+            error_code=event_data.cause.error_code,
+            additional_info=event_data.cause.extracted_message,
+        )
 
-    task_result_repo.mark_error(
-        task_id=event_data.dataset_etl_task_result_id,
-        task_name="Exception Handler Does not Know Failed Task Name",
-        error_code=event_data.cause.error_code,
-        additional_info=event_data.cause.extracted_message,
-    )
-    revision.status = FeedStatus.ERROR
-    revision_repo.update(revision)
-
-    return revision
+    if event_data.fail_dataset_revision:
+        revision_repo = OrganisationDatasetRevisionRepo(db)
+        revision = revision_repo.require_by_id(task_result.revision_id)
+        revision.status = FeedStatus.ERROR
+        revision_repo.update(revision)
 
 
 def lambda_handler(event: dict[str, Any], context: LambdaContext) -> dict[str, Any]:

--- a/src/timetables_etl/exception_handler/app/exception_handler.py
+++ b/src/timetables_etl/exception_handler/app/exception_handler.py
@@ -51,8 +51,10 @@ def lambda_handler(event: dict[str, Any], context: LambdaContext) -> dict[str, A
 
     parsed_event = ExceptionHandlerInputData(**event)
     log.error(
+        "Step Failed",
         parsed_event.cause.error_message,
         error_details=parsed_event.cause,
+        step_name=parsed_event.step_name,
     )
 
     db = SqlDB()

--- a/src/timetables_etl/exception_handler/app/models.py
+++ b/src/timetables_etl/exception_handler/app/models.py
@@ -57,7 +57,7 @@ class ExceptionHandlerInputData(BaseModel):
 
     error: str = Field(alias="Error")
     cause: Annotated[ErrorCause, Field(alias="Cause")]
-    step_name: str | None = Field(alias="StepName", default="unknown")
+    step_name: str = Field(alias="StepName", default="unknown")
 
     dataset_etl_task_result_id: int = Field(alias="DatasetEtlTaskResultId")
 

--- a/src/timetables_etl/exception_handler/app/models.py
+++ b/src/timetables_etl/exception_handler/app/models.py
@@ -57,7 +57,16 @@ class ExceptionHandlerInputData(BaseModel):
 
     error: str = Field(alias="Error")
     cause: Annotated[ErrorCause, Field(alias="Cause")]
+    step_name: str | None = Field(alias="StepName", default="unknown")
+
     dataset_etl_task_result_id: int = Field(alias="DatasetEtlTaskResultId")
+
+    fail_dataset_revision: bool | None = Field(
+        alias="FailDatasetRevision", default=True
+    )
+    fail_dataset_etl_task_result: bool | None = Field(
+        alias="FailDatasetETLTaskResult", default=True
+    )
 
     @model_validator(mode="before")
     @classmethod

--- a/tests/timetables_etl/exception_handler/test_exception_handler.py
+++ b/tests/timetables_etl/exception_handler/test_exception_handler.py
@@ -73,6 +73,7 @@ ZIP_NOT_FOUND_CAUSE_RAW = (
                 "Error": "ZipNoDataFound",
                 "Cause": ZIP_NOT_FOUND_CAUSE_RAW,
                 "DatasetEtlTaskResultId": 4200,
+                "StepName": "ClamAV and Extraction",
             },
             ETLErrorCode.NO_DATA_FOUND,
             "Zip file contains no XML files.",
@@ -83,6 +84,7 @@ ZIP_NOT_FOUND_CAUSE_RAW = (
                 "Error": "Runtime.ExitError",
                 "Cause": '{"errorType":"Runtime.ExitError","errorMessage":"RequestId: d018ab48-c1d6-4075-9721-fe8ee92e458a Error: Runtime exited with error: signal: killed"}',
                 "DatasetEtlTaskResultId": 72118,
+                "StepName": "Download Dataset",
             },
             ETLErrorCode.SYSTEM_ERROR,
             "RequestId: d018ab48-c1d6-4075-9721-fe8ee92e458a Error: Runtime exited with error: signal: killed",
@@ -93,6 +95,7 @@ ZIP_NOT_FOUND_CAUSE_RAW = (
                 "Error": "Lambda.Unknown",
                 "Cause": 'The cause could not be determined because Lambda did not return an error type. Returned payload: {"errorMessage":"2025-03-25T14:59:02.758Z 92f6dcea-87c0-4e89-9a9e-294239bffbb9 Task timed out after 902.11 seconds"}',
                 "DatasetEtlTaskResultId": 1234,
+                "StepName": "Download Dataset",
             },
             ETLErrorCode.SYSTEM_ERROR,
             'The cause could not be determined because Lambda did not return an error type. Returned payload: {"errorMessage":"2025-03-25T14:59:02.758Z 92f6dcea-87c0-4e89-9a9e-294239bffbb9 Task timed out after 902.11 seconds"}',
@@ -121,7 +124,7 @@ def test_lambda_handler(
 
     m_task_result_repo.mark_error.assert_called_once_with(
         task_id=event["DatasetEtlTaskResultId"],
-        task_name="Exception Handler Does not Know Failed Task Name",
+        task_name=event["StepName"],
         error_code=expected_error_code,
         additional_info=expected_additional_info,
     )


### PR DESCRIPTION
Key Details:

- Add StepName input parameter to exception handler
  - Log the failed step + populate task_name_failed field in the DatasetETLTaskResult
- Add FailDatasetRevision and FailDatasetETLTaskResult input parameters to exception handler
  - Adds control for whether or not to fail the DatasetRevision and the DatasetETLTaskResult
- Add catch block to DQS Trigger to mark only the DatasetETLTaskResult as failed, not the DatasetRevision (matches existing bods celery behaviour)
- Add exception handler to file-level processing steps for consistent logging (without failing task result or revision)


Here is an example of how we can use this to filter failures in datadog by step:

<img width="1559" alt="Screenshot 2025-04-04 at 11 25 01" src="https://github.com/user-attachments/assets/1a7fea8a-3d3d-4749-8434-d3b137eb8ab5" />


JIRA: https://kpmgengineering.atlassian.net/browse/BODS-8719