### PR TITLE
fix(DownloadDataset): Make remote filename for S3 unique when downloading from URL + increase memory allocation

### DIFF
--- a/src/timetables_etl/download_dataset/app/download_dataset.py
+++ b/src/timetables_etl/download_dataset/app/download_dataset.py
@@ -47,9 +47,10 @@ def make_remote_file_name(
     url_path = Path(revision.url_link)
 
     if url_path.suffix in (".zip", ".xml"):
-        name = unquote(url_path.name)
+        file_name = unquote(url_path.name)
+        name = f"{revision.dataset_id}_{revision.id}_{now}_{file_name}"
     else:
-        name = f"remote_dataset_{revision.dataset_id}_{now}.{filetype}"
+        name = f"{revision.dataset_id}_{revision.id}_{now}.{filetype}"
 
     return name
 

--- a/timetables-etl.yaml
+++ b/timetables-etl.yaml
@@ -197,6 +197,9 @@ Resources:
       Role: !GetAtt CommonLambdaExecutionRole.Arn
       CodeUri: ./src/timetables_etl/download_dataset
       Handler: app.download_dataset.lambda_handler
+      MemorySize: 512
+      EphemeralStorage:
+        Size: 1024
       Layers:
         - !Ref BoilerplateLambdaLayerArn
       LoggingConfig:


### PR DESCRIPTION
Key Details:

- Right now we're just using the filename from the end of the `revision.url_link`, which is not unique (for example http://test.com/current.zip and http://other-url.com/current.zip would produce the same remote filename which is then uploaded to S3
- In this PR we add the `dataset_id`, `revision_id` and current datetime to the remote file name (S3 object key) to avoid collisions/overwrites
- Increase memory allocation for DownloadDataset lambda to avoid OOM exceptions

https://kpmgengineering.atlassian.net/browse/BODS-8750
