### PR TITLE
fix(Fares): Implement semaphores

### DIFF
--- a/fares-etl.yaml
+++ b/fares-etl.yaml
@@ -149,6 +149,7 @@ Resources:
         FaresValidationLambdaArn: !GetAtt FaresValidationLambda.Arn
         MetadataAggregationLambdaArn: !GetAtt FaresMetadataAggregationLambda.Arn
         DefaultS3BucketName: !Sub 'bodds-${Environment}'
+        FaresSemaphoreDynamoDbTableName: !Ref FaresSemaphore
 
   ##########################
   #### LAMBDA FUNCTIONS ####
@@ -246,6 +247,40 @@ Resources:
           - IsNotLocal
           - !Sub '{{resolve:ssm:/bodds/${Environment}/kms-key-arn}}'
           - !Ref AWS::NoValue
+
+  FaresSemaphore:
+    # checkov:skip=CKV_AWS_28: DB stores lock to prevent more than one state machine from executing at the same time
+    # checkov:skip=CKV_AWS_119: Data is just a job id
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: !Sub '${ProjectName}-${Environment}-${SubFunction}-fares-semaphore'
+      AttributeDefinitions:
+        - AttributeName: LockName
+          AttributeType: S
+      KeySchema:
+        - AttributeName: LockName
+          KeyType: HASH
+      BillingMode: PAY_PER_REQUEST
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: false
+      SSESpecification:
+        SSEEnabled: true
+        SSEType: 'KMS'
+        KMSMasterKeyId: !If
+          - IsNotLocal
+          - !Sub '{{resolve:ssm:/bodds/${Environment}/kms-key-arn}}'
+          - !Ref AWS::NoValue
+
+  StateMachineToDynamoLockTable:
+    Type: AWS::Serverless::Connector
+    Properties:
+      Source:
+        Id: FaresStateMachine
+      Destination:
+        Id: FaresSemaphore
+      Permissions:
+        - Read
+        - Write
 
   ###################
   #### IAM ROLES ####

--- a/src/fares_etl.statemachine.json
+++ b/src/fares_etl.statemachine.json
@@ -396,6 +396,7 @@
         "DatasetEtlTaskResultId": "{% $DatasetEtlTaskResultId %}",
         "PublishDatasetRevision": "{% $publishDatasetRevision %}",
         "OverwriteInputDataset": "{% $overwriteInputDataset %}",
+        "DatasetType": "{% $datasetType %}",
         "lockacquiredtime": "{% $lockacquiredtime %}"
       },
       "Catch": [

--- a/src/fares_etl.statemachine.json
+++ b/src/fares_etl.statemachine.json
@@ -52,22 +52,60 @@
           "#lockownerid": "{% $lock_entry %}"
         },
         "ExpressionAttributeValues": {
-          ":increase": { "N": "1" },
-          ":limit": { "N": "{% $string($concurrency_limit) %}" },
-          ":lockacquiredtime": { "S": "{% $states.context.State.EnteredTime %}" }
+          ":increase": {
+            "N": "1"
+          },
+          ":limit": {
+            "N": "{% $string($concurrency_limit) %}"
+          },
+          ":lockacquiredtime": {
+            "S": "{% $states.context.State.EnteredTime %}"
+          }
         },
         "UpdateExpression": "SET #currentlockcount = #currentlockcount + :increase, #lockownerid = :lockacquiredtime",
         "ConditionExpression": "currentlockcount <> :limit and attribute_not_exists(#lockownerid)",
         "ReturnValues": "UPDATED_NEW"
       },
       "Retry": [
-        { "ErrorEquals": ["DynamoDB.AmazonDynamoDBException"], "MaxAttempts": 0 },
-        { "ErrorEquals": ["States.ALL"], "MaxAttempts": 6, "BackoffRate": 2 }
+        {
+          "ErrorEquals": [
+            "DynamoDB.AmazonDynamoDBException"
+          ],
+          "MaxAttempts": 0
+        },
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "MaxAttempts": 6,
+          "BackoffRate": 2
+        }
       ],
       "Catch": [
-        { "ErrorEquals": ["DynamoDB.AmazonDynamoDBException"], "Next": "InitializeLockItem", "Output": "$lockinfo.acquisitionerror" },
-        { "ErrorEquals": ["DynamoDB.ConditionalCheckFailedException"], "Next": "GetCurrentLockRecord", "Output": "$lockinfo.acquisitionerror" },
-        { "ErrorEquals": ["States.ALL"], "Next": "ParentExceptionHandler", "Output": { "errorInfo": "$.error", "stepName": "AcquireLock" } }
+        {
+          "ErrorEquals": [
+            "DynamoDB.AmazonDynamoDBException"
+          ],
+          "Next": "InitializeLockItem",
+          "Output": "$lockinfo.acquisitionerror"
+        },
+        {
+          "ErrorEquals": [
+            "DynamoDB.ConditionalCheckFailedException"
+          ],
+          "Next": "GetCurrentLockRecord",
+          "Output": "$lockinfo.acquisitionerror"
+        },
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Next": "ParentExceptionHandler",
+          "Output": {
+            "errorInfo": "$.error",
+            "stepName": "AcquireLock"
+          }
+        }
       ],
       "Next": "InitializePipeline"
     },
@@ -77,16 +115,27 @@
       "Arguments": {
         "TableName": "${FaresSemaphoreDynamoDbTableName}",
         "Item": {
-          "LockName": { "S": "{% $lock_name %}" },
-          "currentlockcount": { "N": "0" }
+          "LockName": {
+            "S": "{% $lock_name %}"
+          },
+          "currentlockcount": {
+            "N": "0"
+          }
         },
         "ConditionExpression": "LockName <> :lockname",
         "ExpressionAttributeValues": {
-          ":lockname": { "S": "{% $lock_name %}" }
+          ":lockname": {
+            "S": "{% $lock_name %}"
+          }
         }
       },
       "Catch": [
-        { "ErrorEquals": ["States.ALL"], "Next": "AcquireLock" }
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Next": "AcquireLock"
+        }
       ],
       "Next": "AcquireLock"
     },
@@ -99,7 +148,9 @@
           "#lockownerid": "{% $lock_entry %}"
         },
         "Key": {
-          "LockName": { "S": "{% $lock_name %}" }
+          "LockName": {
+            "S": "{% $lock_name %}"
+          }
         },
         "ProjectionExpression": "#lockownerid"
       },
@@ -113,7 +164,10 @@
     "CheckIfLockAlreadyAcquired": {
       "Type": "Choice",
       "Choices": [
-        { "Condition": "{% $exists($ItemString) and $contains($ItemString, 'Z') %}", "Next": "InitializePipeline" }
+        {
+          "Condition": "{% $exists($ItemString) and $contains($ItemString, 'Z') %}",
+          "Next": "InitializePipeline"
+        }
       ],
       "Default": "WaitToGetLock"
     },
@@ -136,10 +190,13 @@
       },
       "Catch": [
         {
-          "ErrorEquals": ["States.ALL"],
+          "ErrorEquals": [
+            "States.ALL"
+          ],
           "Next": "ParentExceptionHandler",
           "Output": {
-            "errorInfo": "{% $states.errorOutput %}"
+            "errorInfo": "{% $states.errorOutput %}",
+            "stepName": "InitializePipeline"
           }
         }
       ]
@@ -175,10 +232,13 @@
       },
       "Catch": [
         {
-          "ErrorEquals": ["States.ALL"],
+          "ErrorEquals": [
+            "States.ALL"
+          ],
           "Next": "ParentExceptionHandler",
           "Output": {
-            "errorInfo": "{% $states.errorOutput %}"
+            "errorInfo": "{% $states.errorOutput %}",
+            "stepName": "DownloadDataset"
           }
         }
       ]
@@ -197,13 +257,15 @@
       "Assign": {
         "ExtractedSubFolder": "{% $states.result.body.generatedPrefix %}"
       },
-
       "Catch": [
         {
-          "ErrorEquals": ["States.ALL"],
+          "ErrorEquals": [
+            "States.ALL"
+          ],
           "Next": "ParentExceptionHandler",
           "Output": {
-            "errorInfo": "{% $states.errorOutput %}"
+            "errorInfo": "{% $states.errorOutput %}",
+            "stepName": "ClamAvScanner"
           }
         }
       ]
@@ -255,7 +317,6 @@
               "datasetEtlTaskResultId": "{% $states.input.mapDatasetEtlTaskResultId %}"
             }
           },
-
           "FileValidation": {
             "Type": "Task",
             "Next": "SchemaCheck",
@@ -270,10 +331,13 @@
             },
             "Catch": [
               {
-                "ErrorEquals": ["States.ALL"],
+                "ErrorEquals": [
+                  "States.ALL"
+                ],
                 "Next": "ExceptionHandler",
                 "Output": {
-                  "errorInfo": "{% $states.errorOutput %}"
+                  "errorInfo": "{% $states.errorOutput %}",
+                  "stepName": "FileValidation"
                 }
               }
             ]
@@ -291,13 +355,15 @@
             "Output": {
               "schemaCheck": "{% $states.result %}"
             },
-
             "Catch": [
               {
-                "ErrorEquals": ["States.ALL"],
+                "ErrorEquals": [
+                  "States.ALL"
+                ],
                 "Next": "ExceptionHandler",
                 "Output": {
-                  "errorInfo": "{% $states.errorOutput %}"
+                  "errorInfo": "{% $states.errorOutput %}",
+                  "stepName": "SchemaCheck"
                 }
               }
             ]
@@ -315,13 +381,15 @@
             "Output": {
               "faresValidation": "{% $states.result %}"
             },
-
             "Catch": [
               {
-                "ErrorEquals": ["States.ALL"],
+                "ErrorEquals": [
+                  "States.ALL"
+                ],
                 "Next": "ExceptionHandler",
                 "Output": {
-                  "errorInfo": "{% $states.errorOutput %}"
+                  "errorInfo": "{% $states.errorOutput %}",
+                  "stepName": "FaresValidation"
                 }
               }
             ]
@@ -341,10 +409,13 @@
             },
             "Catch": [
               {
-                "ErrorEquals": ["States.ALL"],
+                "ErrorEquals": [
+                  "States.ALL"
+                ],
                 "Next": "ExceptionHandler",
                 "Output": {
-                  "errorInfo": "{% $states.errorOutput %}"
+                  "errorInfo": "{% $states.errorOutput %}",
+                  "stepName": "EtlProcess"
                 }
               }
             ]
@@ -352,9 +423,21 @@
           "Success": {
             "Type": "Succeed"
           },
-          "ExceptionHandler": {
-            "Type": "Pass",
-            "Next": "Fail"
+          "FileLevelExceptionHandler": {
+            "Type": "Task",
+            "Next": "Fail",
+            "Resource": "${ExceptionHandlerLambdaArn}",
+            "Arguments": {
+              "Error": "{% $states.input.errorInfo.Error %}",
+              "Cause": "{% $states.input.errorInfo.Cause %}",
+              "DatasetEtlTaskResultId": "{% $datasetEtlTaskResultId %}",
+              "DatasetRevisionId": "{% $DatasetRevisionId %}",
+              "DatasetType": "{% $DatasetType %}",
+              "StepName": "{% $states.input.stepName %}",
+              "ObjectKey": "{% $ObjectKey %}",
+              "FailDatasetRevision": false,
+              "FailDatasetETLTaskResult": false
+            }
           },
           "Fail": {
             "Type": "Fail",
@@ -374,10 +457,13 @@
       "Output": "{% $states.input %}",
       "Catch": [
         {
-          "ErrorEquals": ["States.ALL"],
+          "ErrorEquals": [
+            "States.ALL"
+          ],
           "Next": "ParentExceptionHandler",
           "Output": {
-            "errorInfo": "{% $states.errorOutput %}"
+            "errorInfo": "{% $states.errorOutput %}",
+            "stepName": "MetadataAggregation"
           }
         }
       ]
@@ -400,7 +486,16 @@
         "lockacquiredtime": "{% $lockacquiredtime %}"
       },
       "Catch": [
-        { "ErrorEquals": ["States.ALL"], "Next": "ParentExceptionHandler", "Output": { "errorInfo": "{% $states.errorOutput %}" } }
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Next": "ParentExceptionHandler",
+          "Output": {
+            "errorInfo": "{% $states.errorOutput %}"
+          },
+          "stepName": "GenerateOutputZip"
+        }
       ]
     },
     "ReleaseLock": {
@@ -410,26 +505,55 @@
       "Arguments": {
         "TableName": "${FaresSemaphoreDynamoDbTableName}",
         "Key": {
-          "LockName": { "S": "{% $lock_name %}" }
+          "LockName": {
+            "S": "{% $lock_name %}"
+          }
         },
         "ExpressionAttributeNames": {
           "#currentlockcount": "currentlockcount",
           "#lockownerid": "{% $lock_entry %}"
         },
         "ExpressionAttributeValues": {
-          ":decrease": { "N": "1" }
+          ":decrease": {
+            "N": "1"
+          }
         },
         "UpdateExpression": "SET #currentlockcount = #currentlockcount - :decrease REMOVE #lockownerid",
         "ConditionExpression": "attribute_exists(#lockownerid)",
         "ReturnValues": "UPDATED_NEW"
       },
       "Retry": [
-        { "ErrorEquals": ["DynamoDB.ConditionalCheckFailedException"], "MaxAttempts": 0 },
-        { "ErrorEquals": ["States.ALL"], "MaxAttempts": 5, "BackoffRate": 1.5 }
+        {
+          "ErrorEquals": [
+            "DynamoDB.ConditionalCheckFailedException"
+          ],
+          "MaxAttempts": 0
+        },
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "MaxAttempts": 5,
+          "BackoffRate": 1.5
+        }
       ],
       "Catch": [
-        { "ErrorEquals": ["DynamoDB.ConditionalCheckFailedException"], "Next": "Completed" },
-        { "ErrorEquals": ["States.ALL"], "Next": "ReleaseLockExceptionHandler", "Output": { "errorInfo": "$.error", "stepName": "Release Lock" } }
+        {
+          "ErrorEquals": [
+            "DynamoDB.ConditionalCheckFailedException"
+          ],
+          "Next": "Completed"
+        },
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Next": "ReleaseLockExceptionHandler",
+          "Output": {
+            "errorInfo": "$.error",
+            "stepName": "Release Lock"
+          }
+        }
       ]
     },
     "ParentExceptionHandler": {
@@ -456,25 +580,45 @@
       "Arguments": {
         "TableName": "${FaresSemaphoreDynamoDbTableName}",
         "Key": {
-          "LockName": { "S": "{% $lock_name %}" }
+          "LockName": {
+            "S": "{% $lock_name %}"
+          }
         },
         "ExpressionAttributeNames": {
           "#currentlockcount": "currentlockcount",
           "#lockownerid": "{% $lock_entry %}"
         },
         "ExpressionAttributeValues": {
-          ":decrease": { "N": "1" }
+          ":decrease": {
+            "N": "1"
+          }
         },
         "UpdateExpression": "SET #currentlockcount = #currentlockcount - :decrease REMOVE #lockownerid",
         "ConditionExpression": "attribute_exists(#lockownerid)",
         "ReturnValues": "UPDATED_NEW"
       },
       "Retry": [
-        { "ErrorEquals": ["DynamoDB.ConditionalCheckFailedException"], "MaxAttempts": 0 },
-        { "ErrorEquals": ["States.ALL"], "MaxAttempts": 5, "BackoffRate": 1.5 }
+        {
+          "ErrorEquals": [
+            "DynamoDB.ConditionalCheckFailedException"
+          ],
+          "MaxAttempts": 0
+        },
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "MaxAttempts": 5,
+          "BackoffRate": 1.5
+        }
       ],
       "Catch": [
-        { "ErrorEquals": ["States.ALL"], "Next": "ParentFail" }
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Next": "ParentFail"
+        }
       ]
     },
     "ParentFail": {

--- a/src/fares_etl.statemachine.json
+++ b/src/fares_etl.statemachine.json
@@ -4,7 +4,7 @@
   "States": {
     "ProcessInput": {
       "Type": "Pass",
-      "Next": "InitializePipeline",
+      "Next": "ValidateLockInputs",
       "Assign": {
         "inputDataSource": "{% $states.input.inputDataSource %}",
         "datasetRevisionId": "{% $states.input.datasetRevisionId %}",
@@ -13,8 +13,114 @@
         "s3Bucket": "{% $exists($states.input.s3.bucket) ? $states.input.s3.bucket : '${DefaultS3BucketName}' %}",
         "s3Object": "{% $exists($states.input.s3.object) ? $states.input.s3.object : null %}",
         "publishDatasetRevision": "{% $exists($states.input.publishDatasetRevision) ? $states.input.publishDatasetRevision : false %}",
-        "overwriteInputDataset": "{% $exists($states.input.overwriteInputDataset) ? $states.input.overwriteInputDataset : true %}"
+        "overwriteInputDataset": "{% $exists($states.input.overwriteInputDataset) ? $states.input.overwriteInputDataset : true %}",
+        "lock_name": "bods-backend-fares-semaphore",
+        "concurrency_limit": 10,
+        "lock_entry": "{% $uuid() %}"
       }
+    },
+    "ValidateLockInputs": {
+      "Type": "Choice",
+      "Default": "LockConfigurationError",
+      "Choices": [
+        {
+          "Condition": "{% $exists($lock_name) and $type($lock_name) = 'string' and $exists($concurrency_limit) and $type($concurrency_limit) = 'number' and $exists($lock_entry) and $type($lock_entry) = 'string' %}",
+          "Next": "AcquireLock"
+        }
+      ]
+    },
+    "LockConfigurationError": {
+      "Type": "Fail",
+      "Error": "InsufficientLockInput",
+      "Cause": "Lock parameters are missing or invalid"
+    },
+    "AcquireLock": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::dynamodb:updateItem",
+      "Assign": {
+        "lockacquiredtime": "{% $states.context.State.EnteredTime %}"
+      },
+      "Arguments": {
+        "TableName": "${FaresSemaphoreDynamoDbTableName}",
+        "Key": {
+          "LockName": {
+            "S": "{% $lock_name %}"
+          }
+        },
+        "ExpressionAttributeNames": {
+          "#currentlockcount": "currentlockcount",
+          "#lockownerid": "{% $lock_entry %}"
+        },
+        "ExpressionAttributeValues": {
+          ":increase": { "N": "1" },
+          ":limit": { "N": "{% $string($concurrency_limit) %}" },
+          ":lockacquiredtime": { "S": "{% $states.context.State.EnteredTime %}" }
+        },
+        "UpdateExpression": "SET #currentlockcount = #currentlockcount + :increase, #lockownerid = :lockacquiredtime",
+        "ConditionExpression": "currentlockcount <> :limit and attribute_not_exists(#lockownerid)",
+        "ReturnValues": "UPDATED_NEW"
+      },
+      "Retry": [
+        { "ErrorEquals": ["DynamoDB.AmazonDynamoDBException"], "MaxAttempts": 0 },
+        { "ErrorEquals": ["States.ALL"], "MaxAttempts": 6, "BackoffRate": 2 }
+      ],
+      "Catch": [
+        { "ErrorEquals": ["DynamoDB.AmazonDynamoDBException"], "Next": "InitializeLockItem", "Output": "$lockinfo.acquisitionerror" },
+        { "ErrorEquals": ["DynamoDB.ConditionalCheckFailedException"], "Next": "GetCurrentLockRecord", "Output": "$lockinfo.acquisitionerror" },
+        { "ErrorEquals": ["States.ALL"], "Next": "ParentExceptionHandler", "Output": { "errorInfo": "$.error", "stepName": "AcquireLock" } }
+      ],
+      "Next": "InitializePipeline"
+    },
+    "InitializeLockItem": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::dynamodb:putItem",
+      "Arguments": {
+        "TableName": "${FaresSemaphoreDynamoDbTableName}",
+        "Item": {
+          "LockName": { "S": "{% $lock_name %}" },
+          "currentlockcount": { "N": "0" }
+        },
+        "ConditionExpression": "LockName <> :lockname",
+        "ExpressionAttributeValues": {
+          ":lockname": { "S": "{% $lock_name %}" }
+        }
+      },
+      "Catch": [
+        { "ErrorEquals": ["States.ALL"], "Next": "AcquireLock" }
+      ],
+      "Next": "AcquireLock"
+    },
+    "GetCurrentLockRecord": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::dynamodb:getItem",
+      "Arguments": {
+        "TableName": "${FaresSemaphoreDynamoDbTableName}",
+        "ExpressionAttributeNames": {
+          "#lockownerid": "{% $lock_entry %}"
+        },
+        "Key": {
+          "LockName": { "S": "{% $lock_name %}" }
+        },
+        "ProjectionExpression": "#lockownerid"
+      },
+      "Assign": {
+        "Item": "{% $states.result.Item %}",
+        "ItemString": "{% $string($states.result.Item) %}"
+      },
+      "Output": "$lockinfo.currentlockitem",
+      "Next": "CheckIfLockAlreadyAcquired"
+    },
+    "CheckIfLockAlreadyAcquired": {
+      "Type": "Choice",
+      "Choices": [
+        { "Condition": "{% $exists($ItemString) and $contains($ItemString, 'Z') %}", "Next": "InitializePipeline" }
+      ],
+      "Default": "WaitToGetLock"
+    },
+    "WaitToGetLock": {
+      "Type": "Wait",
+      "Seconds": 30,
+      "Next": "AcquireLock"
     },
     "InitializePipeline": {
       "Type": "Task",
@@ -278,7 +384,7 @@
     },
     "GenerateOutputZip": {
       "Type": "Task",
-      "Next": "Completed",
+      "Next": "ReleaseLock",
       "Resource": "${GenerateOutputZipLambdaArn}",
       "Arguments": {
         "MapRunArn": "{% $states.input.mapResults.MapRunArn %}",
@@ -289,21 +395,45 @@
         "OriginalObjectKey": "{% $s3Object %}",
         "DatasetEtlTaskResultId": "{% $DatasetEtlTaskResultId %}",
         "PublishDatasetRevision": "{% $publishDatasetRevision %}",
-        "OverwriteInputDataset": "{% $overwriteInputDataset %}"
+        "OverwriteInputDataset": "{% $overwriteInputDataset %}",
+        "lockacquiredtime": "{% $lockacquiredtime %}"
       },
       "Catch": [
-        {
-          "ErrorEquals": ["States.ALL"],
-          "Next": "ParentExceptionHandler",
-          "Output": {
-            "errorInfo": "{% $states.errorOutput %}"
-          }
-        }
+        { "ErrorEquals": ["States.ALL"], "Next": "ParentExceptionHandler", "Output": { "errorInfo": "{% $states.errorOutput %}" } }
+      ]
+    },
+    "ReleaseLock": {
+      "Type": "Task",
+      "Next": "Completed",
+      "Resource": "arn:aws:states:::dynamodb:updateItem",
+      "Arguments": {
+        "TableName": "${FaresSemaphoreDynamoDbTableName}",
+        "Key": {
+          "LockName": { "S": "{% $lock_name %}" }
+        },
+        "ExpressionAttributeNames": {
+          "#currentlockcount": "currentlockcount",
+          "#lockownerid": "{% $lock_entry %}"
+        },
+        "ExpressionAttributeValues": {
+          ":decrease": { "N": "1" }
+        },
+        "UpdateExpression": "SET #currentlockcount = #currentlockcount - :decrease REMOVE #lockownerid",
+        "ConditionExpression": "attribute_exists(#lockownerid)",
+        "ReturnValues": "UPDATED_NEW"
+      },
+      "Retry": [
+        { "ErrorEquals": ["DynamoDB.ConditionalCheckFailedException"], "MaxAttempts": 0 },
+        { "ErrorEquals": ["States.ALL"], "MaxAttempts": 5, "BackoffRate": 1.5 }
+      ],
+      "Catch": [
+        { "ErrorEquals": ["DynamoDB.ConditionalCheckFailedException"], "Next": "Completed" },
+        { "ErrorEquals": ["States.ALL"], "Next": "ReleaseLockExceptionHandler", "Output": { "errorInfo": "$.error", "stepName": "Release Lock" } }
       ]
     },
     "ParentExceptionHandler": {
       "Type": "Task",
-      "Next": "ParentFail",
+      "Next": "ReleaseLockExceptionHandler",
       "Resource": "${ExceptionHandlerLambdaArn}",
       "Arguments": {
         "Error": "{% $states.input.errorInfo.Error %}",
@@ -311,13 +441,41 @@
         "DatasetEtlTaskResultId": "{% $DatasetEtlTaskResultId %}"
       }
     },
+    "ReleaseLockExceptionHandler": {
+      "Type": "Task",
+      "Next": "ParentFail",
+      "Resource": "arn:aws:states:::dynamodb:updateItem",
+      "Arguments": {
+        "TableName": "${FaresSemaphoreDynamoDbTableName}",
+        "Key": {
+          "LockName": { "S": "{% $lock_name %}" }
+        },
+        "ExpressionAttributeNames": {
+          "#currentlockcount": "currentlockcount",
+          "#lockownerid": "{% $lock_entry %}"
+        },
+        "ExpressionAttributeValues": {
+          ":decrease": { "N": "1" }
+        },
+        "UpdateExpression": "SET #currentlockcount = #currentlockcount - :decrease REMOVE #lockownerid",
+        "ConditionExpression": "attribute_exists(#lockownerid)",
+        "ReturnValues": "UPDATED_NEW"
+      },
+      "Retry": [
+        { "ErrorEquals": ["DynamoDB.ConditionalCheckFailedException"], "MaxAttempts": 0 },
+        { "ErrorEquals": ["States.ALL"], "MaxAttempts": 5, "BackoffRate": 1.5 }
+      ],
+      "Catch": [
+        { "ErrorEquals": ["States.ALL"], "Next": "ParentFail" }
+      ]
+    },
     "ParentFail": {
       "Type": "Fail",
       "Comment": "Entire ETL Pipeline Failed"
     },
     "Completed": {
       "Type": "Succeed",
-      "Comment": "ETL Process Successully Completed"
+      "Comment": "ETL Process Successfully Completed"
     }
   }
 }

--- a/src/fares_etl.statemachine.json
+++ b/src/fares_etl.statemachine.json
@@ -438,8 +438,15 @@
       "Resource": "${ExceptionHandlerLambdaArn}",
       "Arguments": {
         "Error": "{% $states.input.errorInfo.Error %}",
-        "Cause": "{% $parse($states.input.errorInfo.Cause) %}",
-        "DatasetEtlTaskResultId": "{% $DatasetEtlTaskResultId %}"
+        "Cause": "{% $states.input.errorInfo.Cause %}",
+        "DatasetEtlTaskResultId": "{% $DatasetEtlTaskResultId %}",
+        "DatasetRevisionId": "{% $datasetRevisionId %}",
+        "DatasetType": "{% $datasetType %}",
+        "StepName": "{% $exists($states.input.stepName) ? $states.input.stepName : 'unknown' %}",
+        "ObjectKey": "{% $s3Object %}",
+        "Url": "{% $url %}",
+        "FailDatasetRevision": "{% $exists($states.input.failDatasetRevision) ? $states.input.failDatasetRevision : true %}",
+        "FailDatasetETLTaskResult": "{% $exists($states.input.failDatasetETLTaskResult) ? $states.input.failDatasetRevision : true %}"
       }
     },
     "ReleaseLockExceptionHandler": {

--- a/src/fares_etl.statemachine.json
+++ b/src/fares_etl.statemachine.json
@@ -334,7 +334,7 @@
                 "ErrorEquals": [
                   "States.ALL"
                 ],
-                "Next": "ExceptionHandler",
+                "Next": "FileLevelExceptionHandler",
                 "Output": {
                   "errorInfo": "{% $states.errorOutput %}",
                   "stepName": "FileValidation"
@@ -360,7 +360,7 @@
                 "ErrorEquals": [
                   "States.ALL"
                 ],
-                "Next": "ExceptionHandler",
+                "Next": "FileLevelExceptionHandler",
                 "Output": {
                   "errorInfo": "{% $states.errorOutput %}",
                   "stepName": "SchemaCheck"
@@ -386,7 +386,7 @@
                 "ErrorEquals": [
                   "States.ALL"
                 ],
-                "Next": "ExceptionHandler",
+                "Next": "FileLevelExceptionHandler",
                 "Output": {
                   "errorInfo": "{% $states.errorOutput %}",
                   "stepName": "FaresValidation"
@@ -412,7 +412,7 @@
                 "ErrorEquals": [
                   "States.ALL"
                 ],
-                "Next": "ExceptionHandler",
+                "Next": "FileLevelExceptionHandler",
                 "Output": {
                   "errorInfo": "{% $states.errorOutput %}",
                   "stepName": "EtlProcess"
@@ -492,9 +492,9 @@
           ],
           "Next": "ParentExceptionHandler",
           "Output": {
-            "errorInfo": "{% $states.errorOutput %}"
-          },
-          "stepName": "GenerateOutputZip"
+            "errorInfo": "{% $states.errorOutput %}",
+            "stepName": "GenerateOutputZip"
+          }
         }
       ]
     },


### PR DESCRIPTION
In this PR:
- Implement the same semaphore logic in Fares that we have in Timetables. Aside from the additional functionality, this also fixes validation issues we were seeing executing the `GenerateOutputZip` (by adding missing input params; `DatasetType` and `lockacquiredtime`)
- Fix input parameters for exception handler + add exception handler to file-level processing for consistent logging purposes

JIRA: https://kpmgengineering.atlassian.net/browse/BODS-8773