### PR TITLE
fix(Fares): Fix fares initialize pipeline payload

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: v1.0.137
+version: v1.0.138

--- a/src/fares_etl.statemachine.json
+++ b/src/fares_etl.statemachine.json
@@ -8,6 +8,7 @@
       "Assign": {
         "inputDataSource": "{% $states.input.inputDataSource %}",
         "datasetRevisionId": "{% $states.input.datasetRevisionId %}",
+        "datasetETLTaskResultId": "{% $exists($states.input.datasetETLTaskResultId) ? $states.input.datasetETLTaskResultId : null %}",
         "datasetType": "{% $states.input.datasetType %}",
         "url": "{% $exists($states.input.url) ? $states.input.url : null %}",
         "s3Bucket": "{% $exists($states.input.s3.bucket) ? $states.input.s3.bucket : '${DefaultS3BucketName}' %}",

--- a/src/fares_etl.statemachine.json
+++ b/src/fares_etl.statemachine.json
@@ -183,7 +183,8 @@
       "Arguments": {
         "Bucket": "{% $s3Bucket %}",
         "ObjectKey": "{% $s3Object %}",
-        "DatasetRevisionId": "{% $datasetRevisionId %}"
+        "DatasetRevisionId": "{% $datasetRevisionId %}",
+        "DatasetETLTaskResultId": "{% $datasetETLTaskResultId %}"
       },
       "Assign": {
         "DatasetEtlTaskResultId": "{% $states.result.DatasetEtlTaskResultId %}"


### PR DESCRIPTION
We noticed that the `DatasetETLTaskResultId` input was missing, which would cause the state machine to create a new one itself (which is only intended for testing in isolation; usually Django is responsible for creating the task result)