### PR TITLE
fix(GenerateOutputZip): Populate missing revision metadata fields

### DIFF
--- a/src/boilerplate/common_layer/database/dataclasses/__init__.py
+++ b/src/boilerplate/common_layer/database/dataclasses/__init__.py
@@ -1,0 +1,3 @@
+from .stats import RevisionStats, ServiceStats, TXCFileStats
+
+__all__ = ["RevisionStats", "ServiceStats", "TXCFileStats"]

--- a/src/boilerplate/common_layer/database/dataclasses/__init__.py
+++ b/src/boilerplate/common_layer/database/dataclasses/__init__.py
@@ -1,3 +1,7 @@
+"""
+Module exports for dataclasses
+"""
+
 from .stats import RevisionStats, ServiceStats, TXCFileStats
 
 __all__ = ["RevisionStats", "ServiceStats", "TXCFileStats"]

--- a/src/boilerplate/common_layer/database/dataclasses/stats.py
+++ b/src/boilerplate/common_layer/database/dataclasses/stats.py
@@ -1,3 +1,7 @@
+"""
+Dataclasses for reporting stats
+"""
+
 from dataclasses import dataclass
 from datetime import date, datetime
 

--- a/src/boilerplate/common_layer/database/dataclasses/stats.py
+++ b/src/boilerplate/common_layer/database/dataclasses/stats.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass
+from datetime import date, datetime
+
+
+@dataclass
+class RevisionStats:
+    publisher_creation_datetime: datetime | None = None
+    publisher_modification_datetime: datetime | None = None
+    first_expiring_service: date | None = None
+    last_expiring_service: date | None = None
+    first_service_start: date | None = None
+
+
+@dataclass
+class ServiceStats:
+    first_service_start: date | None
+    first_expiring_service: date | None
+    last_expiring_service: date | None
+
+
+@dataclass
+class TXCFileStats:
+    first_creation_datetime: datetime | None
+    last_modification_datetime: datetime | None

--- a/src/boilerplate/common_layer/database/dataclasses/stats.py
+++ b/src/boilerplate/common_layer/database/dataclasses/stats.py
@@ -4,6 +4,10 @@ from datetime import date, datetime
 
 @dataclass
 class RevisionStats:
+    """
+    Summary stats for a Dataset Revision
+    """
+
     publisher_creation_datetime: datetime | None = None
     publisher_modification_datetime: datetime | None = None
     first_expiring_service: date | None = None
@@ -13,6 +17,10 @@ class RevisionStats:
 
 @dataclass
 class ServiceStats:
+    """
+    Summary stats for a group of Services
+    """
+
     first_service_start: date | None
     first_expiring_service: date | None
     last_expiring_service: date | None
@@ -20,5 +28,9 @@ class ServiceStats:
 
 @dataclass
 class TXCFileStats:
+    """
+    Summary stats for a group of TXC File Attributes
+    """
+
     first_creation_datetime: datetime | None
     last_modification_datetime: datetime | None

--- a/src/boilerplate/common_layer/database/repos/repo_organisation.py
+++ b/src/boilerplate/common_layer/database/repos/repo_organisation.py
@@ -5,10 +5,11 @@ SQLAlchemy Organisation Repos
 from datetime import UTC, datetime
 
 from common_layer.enums import FeedStatus
-from sqlalchemy import and_
+from sqlalchemy import and_, func, select
 from structlog.stdlib import get_logger
 
 from ..client import SqlDB
+from ..dataclasses import RevisionStats, TXCFileStats
 from ..exceptions import (
     OrganisationDatasetNotFound,
     OrganisationDatasetRevisionNotFound,
@@ -23,6 +24,7 @@ from ..models import (
 )
 from .operation_decorator import handle_repository_errors
 from .repo_common import BaseRepositoryWithId
+from .utils import date_to_datetime
 
 log = get_logger()
 
@@ -189,6 +191,36 @@ class OrganisationDatasetRevisionRepo(
 
         self._execute_update(update_record, statement)
 
+    @handle_repository_errors
+    def update_stats(self, revision_id: int, revision_stats: RevisionStats) -> None:
+        """
+        Update fields on a dataset revision using the values from RevisionStats.
+        """
+        statement = self._build_query().where(self._model.id == revision_id)
+
+        def update_record(record: OrganisationDatasetRevision) -> None:
+            log.info("Updating metadata fields for revision", revision_id=record.id)
+
+            record.publisher_creation_datetime = (
+                revision_stats.publisher_creation_datetime
+            )
+            record.publisher_modified_datetime = (
+                revision_stats.publisher_modification_datetime
+            )
+            record.first_expiring_service = date_to_datetime(
+                revision_stats.first_expiring_service
+            )
+            record.last_expiring_service = date_to_datetime(
+                revision_stats.last_expiring_service
+            )
+            record.first_service_start = date_to_datetime(
+                revision_stats.first_service_start
+            )
+
+            return None
+
+        self._execute_update(update_record, statement)
+
 
 class OrganisationTXCFileAttributesRepo(
     BaseRepositoryWithId[OrganisationTXCFileAttributes]
@@ -241,6 +273,24 @@ class OrganisationTXCFileAttributesRepo(
             self._model.service_code.in_(service_codes)
         )
         return self._fetch_all(statement)
+
+    def get_file_datetime_stats_by_revision_id(self, revision_id: int) -> TXCFileStats:
+        """
+        Return the earliest creation_datetime and latest modification_datetime
+        across all TXC files for a given dataset revision.
+        """
+        stmt = select(
+            func.min(self._model.creation_datetime),
+            func.max(self._model.modification_datetime),
+        ).where(self._model.revision_id == revision_id)
+
+        with self._db.session_scope() as session:
+            result = session.execute(stmt).one_or_none()
+            if result is None:
+                return TXCFileStats(None, None)
+            return TXCFileStats(
+                first_creation_datetime=result[0], last_modification_datetime=result[1]
+            )
 
 
 class OrganisationOrganisationRepo(BaseRepositoryWithId[OrganisationOrganisation]):

--- a/src/boilerplate/common_layer/database/repos/repo_organisation.py
+++ b/src/boilerplate/common_layer/database/repos/repo_organisation.py
@@ -217,8 +217,6 @@ class OrganisationDatasetRevisionRepo(
                 revision_stats.first_service_start
             )
 
-            return None
-
         self._execute_update(update_record, statement)
 
 

--- a/src/boilerplate/common_layer/database/repos/utils.py
+++ b/src/boilerplate/common_layer/database/repos/utils.py
@@ -1,0 +1,8 @@
+from datetime import date, datetime
+
+
+def date_to_datetime(date: date | None) -> datetime | None:
+    """
+    Convert a date to a datetime object with time 00:00:00
+    """
+    return datetime.combine(date, datetime.min.time()) if date else None

--- a/src/boilerplate/common_layer/database/repos/utils.py
+++ b/src/boilerplate/common_layer/database/repos/utils.py
@@ -1,8 +1,12 @@
+"""
+Util functions for database repo classes
+"""
+
 from datetime import date, datetime
 
 
-def date_to_datetime(date: date | None) -> datetime | None:
+def date_to_datetime(date_obj: date | None) -> datetime | None:
     """
-    Convert a date to a datetime object with time 00:00:00
+    Convert date to a datetime object with time 00:00:00
     """
-    return datetime.combine(date, datetime.min.time()) if date else None
+    return datetime.combine(date_obj, datetime.min.time()) if date_obj else None

--- a/src/timetables_etl/generate_output_zip/app/etl_revision_stats.py
+++ b/src/timetables_etl/generate_output_zip/app/etl_revision_stats.py
@@ -1,3 +1,7 @@
+"""
+Module for functions related to revision stats
+"""
+
 from common_layer.database import SqlDB
 from common_layer.database.dataclasses import RevisionStats
 from common_layer.database.repos import (
@@ -19,8 +23,6 @@ def build_revision_stats(revision_id: int, db: SqlDB) -> RevisionStats:
         revision_id
     )
     service_stats = service_repo.get_service_stats_by_revision_id(revision_id)
-
-    # TODO: handle other fields like line_count
 
     return RevisionStats(
         publisher_creation_datetime=txc_file_stats.first_creation_datetime,

--- a/src/timetables_etl/generate_output_zip/app/etl_revision_stats.py
+++ b/src/timetables_etl/generate_output_zip/app/etl_revision_stats.py
@@ -1,0 +1,31 @@
+from common_layer.database import SqlDB
+from common_layer.database.dataclasses import RevisionStats
+from common_layer.database.repos import (
+    OrganisationTXCFileAttributesRepo,
+    TransmodelServiceRepo,
+)
+
+
+def build_revision_stats(revision_id: int, db: SqlDB) -> RevisionStats:
+    """
+    Derive revision stats from related TXC file attributes and services.
+
+    Returns creation/modification datetimes and service date ranges for the given revision.
+    """
+    file_attributes_repo = OrganisationTXCFileAttributesRepo(db)
+    service_repo = TransmodelServiceRepo(db)
+
+    txc_file_stats = file_attributes_repo.get_file_datetime_stats_by_revision_id(
+        revision_id
+    )
+    service_stats = service_repo.get_service_stats_by_revision_id(revision_id)
+
+    # TODO: handle other fields like line_count
+
+    return RevisionStats(
+        publisher_creation_datetime=txc_file_stats.first_creation_datetime,
+        publisher_modification_datetime=txc_file_stats.last_modification_datetime,
+        first_expiring_service=service_stats.first_expiring_service,
+        last_expiring_service=service_stats.last_expiring_service,
+        first_service_start=service_stats.first_service_start,
+    )

--- a/src/timetables_etl/generate_output_zip/app/generate_output_zip.py
+++ b/src/timetables_etl/generate_output_zip/app/generate_output_zip.py
@@ -144,8 +144,8 @@ def update_revision_metadata(revision_id: int, db: SqlDB) -> None:
     """
     Update revision metadata based on all processed TxcFileAttributes and Services
     """
-    log.info("Updating DatasetRevision metadata")
     updated_stats = build_revision_stats(revision_id, db)
+    log.info("Updating DatasetRevision with stats", stats=updated_stats)
     OrganisationDatasetRevisionRepo(db).update_stats(revision_id, updated_stats)
 
 

--- a/src/timetables_etl/generate_output_zip/app/generate_output_zip.py
+++ b/src/timetables_etl/generate_output_zip/app/generate_output_zip.py
@@ -177,7 +177,6 @@ def lambda_handler(event: dict[str, Any], _context: LambdaContext) -> dict[str, 
     input_data = GenerateOutputZipInputData(**event)
     db = SqlDB()
     ETLTaskResultRepo(db).update_progress(input_data.dataset_etl_task_result_id, 90)
-    # TODO: exception handling; should we continue if stats fail?
     update_revision_metadata(input_data.dataset_revision_id, db)
     result = process_map_results(input_data, db)
     ETLTaskResultRepo(db).update_progress(input_data.dataset_etl_task_result_id, 100)

--- a/tests/boilerplate/common_layer/database/repos/test_repo_organization.py
+++ b/tests/boilerplate/common_layer/database/repos/test_repo_organization.py
@@ -1,14 +1,18 @@
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 
 import pytest
+from common_layer.database.client import SqlDB
+from common_layer.database.dataclasses import RevisionStats, TXCFileStats
 from common_layer.database.models.model_organisation import OrganisationDatasetRevision
 from common_layer.database.repos.repo_organisation import (
     OrganisationDatasetRevisionRepo,
+    OrganisationTXCFileAttributesRepo,
 )
 from common_layer.enums import FeedStatus
 from freezegun import freeze_time
 from pytz import UTC
 
+from tests.factories.database import OrganisationTXCFileAttributesFactory
 from tests.factories.database.organisation import OrganisationDatasetRevisionFactory
 
 
@@ -81,3 +85,86 @@ def test_dataset_revision_publish_revision_success(
         )
         for attr, expected_value in expected_state.items():
             assert getattr(record_after_update, attr) == expected_value
+
+
+def test_dataset_revision_update_stats(test_db):
+    repo = OrganisationDatasetRevisionRepo(test_db)
+    revision = OrganisationDatasetRevisionFactory.create(
+        publisher_creation_datetime=None,
+        publisher_modified_datetime=None,
+        first_expiring_service=None,
+        last_expiring_service=None,
+    )
+
+    with test_db.session_scope() as session:
+        session.add(revision)
+        session.flush()
+        session.expunge(revision)
+
+    assert revision.id is not None
+
+    stats = RevisionStats(
+        publisher_creation_datetime=datetime(2024, 12, 1, tzinfo=timezone.utc),
+        publisher_modification_datetime=datetime(2025, 2, 1, tzinfo=timezone.utc),
+        first_expiring_service=datetime(2026, 2, 3, tzinfo=timezone.utc),
+        last_expiring_service=datetime(2027, 1, 5, tzinfo=timezone.utc),
+        first_service_start=datetime(2025, 1, 1, tzinfo=timezone.utc),
+    )
+    repo.update_stats(revision.id, stats)
+
+    updated_revision = repo.get_by_id(revision.id)
+    assert updated_revision is not None
+
+    assert (
+        updated_revision.publisher_creation_datetime
+        == stats.publisher_creation_datetime
+    )
+    assert (
+        updated_revision.publisher_modified_datetime
+        == stats.publisher_modification_datetime
+    )
+    assert updated_revision.first_expiring_service == stats.first_expiring_service
+    assert updated_revision.last_expiring_service == stats.last_expiring_service
+    assert updated_revision.first_service_start == stats.first_service_start
+
+
+def test_txc_file_attributes_get_file_datetime_stats_by_revision_id(test_db: SqlDB):
+
+    revision_id = 123
+    repo = OrganisationTXCFileAttributesRepo(test_db)
+
+    # No file attributes in DB
+    result = repo.get_file_datetime_stats_by_revision_id(revision_id)
+    assert result == TXCFileStats(
+        first_creation_datetime=None, last_modification_datetime=None
+    )
+
+    # Create file attributes
+    earliest_txc_creation_date = datetime(2024, 12, 1, tzinfo=timezone.utc)
+    latest_txc_modification_date = datetime(2025, 1, 10, tzinfo=timezone.utc)
+
+    earliest_created_txc = OrganisationTXCFileAttributesFactory.create(
+        creation_datetime=earliest_txc_creation_date,
+        modification_datetime=datetime(2024, 12, 2),
+        revision_id=revision_id,
+    )
+    latest_modified_txc = OrganisationTXCFileAttributesFactory.create(
+        creation_datetime=datetime(2024, 12, 2),
+        modification_datetime=latest_txc_modification_date,
+        revision_id=revision_id,
+    )
+    unrelated_txc = OrganisationTXCFileAttributesFactory.create(
+        creation_datetime=datetime(2024, 12, 2),
+        modification_datetime=latest_txc_modification_date + timedelta(days=1),
+        revision_id=321,
+    )
+
+    with test_db.session_scope() as session:
+        session.add_all([earliest_created_txc, latest_modified_txc, unrelated_txc])
+        session.commit()
+
+    result = repo.get_file_datetime_stats_by_revision_id(revision_id)
+    assert result == TXCFileStats(
+        first_creation_datetime=earliest_txc_creation_date,
+        last_modification_datetime=latest_txc_modification_date,
+    )

--- a/tests/boilerplate/common_layer/database/repos/test_repo_transmodel.py
+++ b/tests/boilerplate/common_layer/database/repos/test_repo_transmodel.py
@@ -1,0 +1,66 @@
+from datetime import date, datetime, timedelta
+
+from common_layer.database.client import SqlDB
+from common_layer.database.dataclasses import ServiceStats
+from common_layer.database.repos import TransmodelServiceRepo
+
+from tests.factories.database import TransmodelServiceFactory
+
+
+def test_service_repo_get_service_stats_by_revision_id(test_db: SqlDB):
+
+    revision_id = 123
+    repo = TransmodelServiceRepo(test_db)
+
+    result = repo.get_service_stats_by_revision_id(revision_id)
+
+    # No services in DB
+    assert result == ServiceStats(
+        first_service_start=None,
+        first_expiring_service=None,
+        last_expiring_service=None,
+    )
+
+    # Create services
+    earliest_start_date = date(2024, 12, 1)
+    earliest_end_date = date(2025, 1, 10)
+    latest_end_date = date(2025, 1, 13)
+
+    earliest_starting_service = TransmodelServiceFactory.create(
+        start_date=earliest_start_date,
+        end_date=datetime(2025, 1, 11),
+        revision_id=revision_id,
+    )
+    first_expiring_service = TransmodelServiceFactory.create(
+        start_date=datetime(2025, 1, 1),
+        end_date=earliest_end_date,
+        revision_id=revision_id,
+    )
+    last_expiring_service = TransmodelServiceFactory.create(
+        start_date=datetime(2025, 2, 1),
+        end_date=latest_end_date,
+        revision_id=revision_id,
+    )
+    unrelated_service = TransmodelServiceFactory.create(
+        start_date=datetime(2025, 2, 1),
+        end_date=latest_end_date + timedelta(days=1),
+        revision_id=321,
+    )
+
+    with test_db.session_scope() as session:
+        session.add_all(
+            [
+                earliest_starting_service,
+                first_expiring_service,
+                last_expiring_service,
+                unrelated_service,
+            ]
+        )
+        session.commit()
+
+    result = repo.get_service_stats_by_revision_id(revision_id)
+    assert result == ServiceStats(
+        first_service_start=earliest_start_date,
+        first_expiring_service=earliest_end_date,
+        last_expiring_service=latest_end_date,
+    )


### PR DESCRIPTION
In this PR we add some code to the Generate Output Zip step to:
- Build a set of stats based on all services/txc file attributes processed during the ETL step
- Update the revision fields with those stats (`publisher_creation_datetime`, `publisher_modified_datetime`, `first_expiring_service`, `last_expiring_service`, `first_service_start`)

JIRA: https://kpmgengineering.atlassian.net/browse/BODS-8759
