### PR TITLE
feat(timetables-etl): Use performETLOnly variable to skip Schema Checks and PTI

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: v1.0.141
+version: v1.0.142

--- a/src/timetables_etl.statemachine.json
+++ b/src/timetables_etl.statemachine.json
@@ -643,10 +643,24 @@
       "Choices": [
         {
           "Condition": "{% $finalResult.body.successful_files > 0 %}",
-          "Next": "Trigger DQS State Machine"
+          "Next": "Check if DQS needs to be Skipped"
         }
       ],
       "Default": "Release Lock"
+    },
+    "Check if DQS needs to be Skipped": {
+      "Type": "Choice",
+      "Default": "Trigger DQS State Machine",
+      "Choices": [
+        {
+          "Condition": "{% $performETLOnly = false %}",
+          "Next": "Trigger DQS State Machine"
+        },
+        {
+          "Condition": "{% $performETLOnly = true %}",
+          "Next": "Release Lock"
+        }
+      ]
     },
     "Trigger DQS State Machine": {
       "Type": "Task",

--- a/src/timetables_etl.statemachine.json
+++ b/src/timetables_etl.statemachine.json
@@ -303,7 +303,7 @@
             "Default": "File Validation",
             "Choices": [
               {
-                "Condition": "{% $performETLOnly = true %}",
+                "Condition": "{% $performETLOnly = false %}",
                 "Next": "File Validation"
               },
               {
@@ -513,12 +513,12 @@
             "Default": "PTI Validation",
             "Choices": [
               {
-                "Condition": "{% $performETLOnly = true %}",
-                "Next": "Timetables ETL"
+                "Condition": "{% $performETLOnly = false %}",
+                "Next": "PTI Validation"
               },
               {
                 "Condition": "{% $performETLOnly = true %}",
-                "Next": "PTI Validation"
+                "Next": "Timetables ETL"
               }
             ]
           },

--- a/src/timetables_etl.statemachine.json
+++ b/src/timetables_etl.statemachine.json
@@ -289,7 +289,7 @@
         "States": {
           "Process Validation Map Input": {
             "Type": "Pass",
-            "Next": "File Validation",
+            "Next": "Check if Validations need to be Skipped",
             "Assign": {
               "Bucket": "{% $states.input.mapS3Bucket %}",
               "ObjectKey": "{% $states.input.mapS3Object %}",
@@ -297,6 +297,20 @@
               "datasetEtlTaskResultId": "{% $states.input.mapDatasetEtlTaskResultId %}",
               "DatasetType": "{% $states.input.mapDatasetType %}"
             }
+          },
+          "Check if Validations need to be Skipped": {
+            "Type": "Choice",
+            "Default": "File Validation",
+            "Choices": [
+              {
+                "Condition": "{% $performETLOnly = true %}",
+                "Next": "File Validation"
+              },
+              {
+                "Condition": "{% $performETLOnly = true %}",
+                "Next": "FileAttributes ETL"
+              }
+            ]
           },
           "File Validation": {
             "Type": "Task",
@@ -483,7 +497,7 @@
         "States": {
           "Process ETL Map Input": {
             "Type": "Pass",
-            "Next": "PTI Validation",
+            "Next": "Check if PTI needs to be Skipped",
             "Assign": {
               "Bucket": "{% $states.input.mapS3Bucket %}",
               "ObjectKey": "{% $states.input.mapS3Object %}",
@@ -493,6 +507,20 @@
               "FileAttributesEtl": "{% $states.input.mapDatasetFileAttributesEtl %}",
               "DatasetType": "{% $states.input.mapDatasetType %}"
             }
+          },
+          "Check if PTI needs to be Skipped": {
+            "Type": "Choice",
+            "Default": "PTI Validation",
+            "Choices": [
+              {
+                "Condition": "{% $performETLOnly = true %}",
+                "Next": "Timetables ETL"
+              },
+              {
+                "Condition": "{% $performETLOnly = true %}",
+                "Next": "PTI Validation"
+              }
+            ]
           },
           "PTI Validation": {
             "Type": "Task",


### PR DESCRIPTION
In the state machine input payload if `performETLOnly` is `true` then only the File Attributes and ETL Process lambdas will be executed

Skipping:

- ClamAV Scan
- File Validation
- Schema and Post Schema Check
- PTI
- DQS Trigger

JIRA: https://kpmgengineering.atlassian.net/browse/BODS-7715
