### PR TITLE
refactor(txc-parser): Fix linting issues

### DIFF
--- a/src/boilerplate/common_layer/xml/txc/parser/services_flexible.py
+++ b/src/boilerplate/common_layer/xml/txc/parser/services_flexible.py
@@ -14,6 +14,7 @@ from ..models import (
     TXCFlexibleStopUsage,
     TXCPhone,
 )
+from .txc_types import parse_jp_direction
 
 log = get_logger()
 
@@ -71,9 +72,14 @@ def parse_flexible_journey_pattern(
 ) -> TXCFlexibleJourneyPattern | None:
     """Parse flexible journey patterns defining possible stop combinations for flexible routes"""
     pattern_id: str | None = pattern_xml.get("id")
-    direction: str | None = get_element_text(pattern_xml, "Direction")
+    direction: str | None = parse_jp_direction(pattern_xml)
 
     if not pattern_id or not direction:
+        log.warning(
+            "Flexible Journey Pattern Missing ID or Direction",
+            pattern_id=pattern_id,
+            direction=direction,
+        )
         return None
 
     stop_points: list[TXCFlexibleStopUsage | TXCFixedStopUsage] = []

--- a/src/boilerplate/common_layer/xml/txc/parser/stop_points/parse_stop_point_types.py
+++ b/src/boilerplate/common_layer/xml/txc/parser/stop_points/parse_stop_point_types.py
@@ -2,7 +2,7 @@
 Stop Point Types
 """
 
-from typing import cast, get_args
+from typing import get_args
 
 from lxml.etree import _Element  # type: ignore
 
@@ -28,7 +28,7 @@ def parse_bay_structure(bay_xml: _Element) -> BayStructure:
     if timing_status_code:
         timing_status = TIMING_STATUS_MAPPING.get(timing_status_code)
         if timing_status and timing_status in get_args(TimingStatusT):
-            return BayStructure(TimingStatus=cast(TimingStatusT, timing_status))
+            return BayStructure(TimingStatus=timing_status)
 
     return BayStructure()
 


### PR DESCRIPTION
- Use parse_jp_direction to return a JourneyPatternVehicleDirectionT type instead
- Remove unnecessary cast when parsing BayStructures

