### PR TITLE
fix(sam): Increase lambda memory to avoid Out of Memory crashes

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: v1.0.146
+version: v1.0.147

--- a/fares-etl.yaml
+++ b/fares-etl.yaml
@@ -61,7 +61,7 @@ Globals:
       - x86_64
     Runtime: python3.11
     Timeout: 300
-    MemorySize: 256
+    MemorySize: 384
     Layers:
       - !Sub arn:aws:lambda:${AWS::Region}:017000801446:layer:AWSLambdaPowertoolsPythonV3-python311-x86_64:5
       - !Sub 'arn:aws:lambda:${AWS::Region}:580247275435:layer:LambdaInsightsExtension:53'

--- a/timetables-etl.yaml
+++ b/timetables-etl.yaml
@@ -264,7 +264,7 @@ Resources:
       Role: !GetAtt CommonLambdaExecutionRole.Arn
       CodeUri: ./src/timetables_etl/file_attributes_etl
       Handler: app.file_attributes_etl.lambda_handler
-      MemorySize: 768
+      MemorySize: 1024
       Timeout: 300
       Layers:
         - !Ref BoilerplateLambdaLayerArn

--- a/timetables-etl.yaml
+++ b/timetables-etl.yaml
@@ -61,7 +61,7 @@ Globals:
       - x86_64
     Runtime: python3.11
     Timeout: 300
-    MemorySize: 256
+    MemorySize: 384
     Layers:
       - !Sub arn:aws:lambda:${AWS::Region}:017000801446:layer:AWSLambdaPowertoolsPythonV3-python311-x86_64:5
       - !Sub 'arn:aws:lambda:${AWS::Region}:580247275435:layer:LambdaInsightsExtension:53'


### PR DESCRIPTION
The exception handler and intialize pipeline have ran into out of memory erorrs with their default 256mb.

- Increase default lambda memory to 384
- Increase File Attributes ETL memory from 768 to 1024

JIRA: https://kpmgengineering.atlassian.net/browse/BODS-8866
