### PR TITLE
refactor(fares): add extra logs to the fares lambdas

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: v1.0.147
+version: v1.0.148

--- a/src/boilerplate/common_layer/db/constants.py
+++ b/src/boilerplate/common_layer/db/constants.py
@@ -22,3 +22,5 @@ class StepName(str, Enum):
     NETEX_FILE_VALIDATOR = "NeTEx File Validator"
     TXC_ATTRIBUTE_EXTRACTION = "TxC attributes extraction"
     FILE_COLLATION = "Generating list of files to process"
+    FARES_ETL_PROCESS = "File Level ETL for Fares"
+    FARES_METADATA_AGGREGATION = "Dataset Level Aggregation and output of Fares Data"

--- a/src/boilerplate/common_layer/xml/netex/helpers/__init__.py
+++ b/src/boilerplate/common_layer/xml/netex/helpers/__init__.py
@@ -3,3 +3,68 @@ Helper Exports
 
 Useful for tests as we can move things around without having to change imports
 """
+
+from .helpers_composite_frame import (
+    get_composite_frame_valid_from,
+    get_composite_frame_valid_to,
+)
+from .helpers_counts import (
+    number_of_distinct_user_profiles,
+    number_of_fare_zones,
+    number_of_lines,
+    number_of_pass_fare_products,
+    number_of_sales_offer_packages,
+    number_of_trip_fare_products,
+    sort_frames,
+)
+from .helpers_fare_frame_fare_products import (
+    get_fare_products,
+    get_product_names,
+    get_product_types,
+)
+from .helpers_fare_frame_tariff import (
+    earliest_tariff_from_date,
+    get_tariff_basis,
+    get_tariffs_from_fare_frames,
+    get_user_types,
+    latest_tariff_to_date,
+)
+from .helpers_fare_frame_zones import get_scheduled_stop_point_refs
+from .helpers_resource_frame import get_national_operator_codes
+from .helpers_service_frame import (
+    get_atco_area_codes_from_service_frames,
+    get_line_ids_from_service_frames,
+    get_line_public_codes_from_service_frames,
+)
+
+__all__ = [
+    # From helpers_composite_frame
+    "get_composite_frame_valid_from",
+    "get_composite_frame_valid_to",
+    # From helpers_counts
+    "number_of_distinct_user_profiles",
+    "number_of_fare_zones",
+    "number_of_lines",
+    "number_of_pass_fare_products",
+    "number_of_sales_offer_packages",
+    "number_of_trip_fare_products",
+    "sort_frames",
+    # From helpers_fare_frame_fare_products
+    "get_fare_products",
+    "get_product_names",
+    "get_product_types",
+    # From helpers_fare_frame_tariff
+    "earliest_tariff_from_date",
+    "get_tariff_basis",
+    "get_tariffs_from_fare_frames",
+    "get_user_types",
+    "latest_tariff_to_date",
+    # From helpers_fare_frame_zones
+    "get_scheduled_stop_point_refs",
+    # From helpers_resource_frame
+    "get_national_operator_codes",
+    # From helpers_service_frame
+    "get_atco_area_codes_from_service_frames",
+    "get_line_ids_from_service_frames",
+    "get_line_public_codes_from_service_frames",
+]

--- a/src/boilerplate/common_layer/xml/netex/helpers/helpers_fare_frame_fare_products.py
+++ b/src/boilerplate/common_layer/xml/netex/helpers/helpers_fare_frame_fare_products.py
@@ -32,6 +32,7 @@ def get_product_types(
     for product in fare_products:
         if product.ProductType is not None:
             product_types.add(product.ProductType)
+    log.debug("Product Types Calculated", product_types=product_types)
     return list(product_types)
 
 
@@ -45,4 +46,5 @@ def get_product_names(
     for product in fare_products:
         if product.Name is not None:
             product_names.add(product.Name.value)
+    log.debug("Product Names Calculated", product_types=product_names)
     return list(product_names)

--- a/src/boilerplate/common_layer/xml/netex/helpers/helpers_fare_frame_tariff.py
+++ b/src/boilerplate/common_layer/xml/netex/helpers/helpers_fare_frame_tariff.py
@@ -4,7 +4,11 @@ Helper Functions for working with Tariffs in FareFrames
 
 from datetime import datetime
 
+from structlog.stdlib import get_logger
+
 from ..models import FareFrame, Tariff, TariffBasisT, UserProfile, UserTypeT
+
+log = get_logger()
 
 
 def get_tariffs_from_fare_frames(frames: list[FareFrame]) -> list[Tariff]:
@@ -84,5 +88,5 @@ def get_user_types(tariffs: list[Tariff]) -> list[UserTypeT]:
         for limitation in fare_structure.GenericParameterAssignment.limitations
         if isinstance(limitation, UserProfile) and limitation.UserType
     ]
-
+    log.debug("User Types found", user_types=user_types)
     return user_types

--- a/src/boilerplate/common_layer/xml/netex/helpers/helpers_fare_frame_zones.py
+++ b/src/boilerplate/common_layer/xml/netex/helpers/helpers_fare_frame_zones.py
@@ -3,8 +3,11 @@ FareZone Helpers
 """
 
 from common_layer.xml.netex.models.netex_references import ScheduledStopPointReference
+from structlog.stdlib import get_logger
 
 from ..models import FareFrame, FareZone
+
+log = get_logger()
 
 
 def get_fare_zones(frames: list[FareFrame]) -> list[FareZone]:
@@ -32,5 +35,9 @@ def get_scheduled_stop_point_refs(
         if member.ScheduledStopPointRef
         for stop_ref in member.ScheduledStopPointRef
     ]
-
+    log.debug(
+        "ScheduledStopPointRefs across Fare Frames found",
+        fare_zones=fare_zones,
+        stops=stops,
+    )
     return stops

--- a/src/boilerplate/common_layer/xml/netex/helpers/helpers_resource_frame.py
+++ b/src/boilerplate/common_layer/xml/netex/helpers/helpers_resource_frame.py
@@ -23,5 +23,5 @@ def get_national_operator_codes(frames: list[ResourceFrame]) -> list[str]:
                 operator_codes.add(public_code)
             else:
                 log.info("Operator Missing PublicCode", operator_id=operator.id)
-
+    log.debug("National Operator Codes Found", operator_codes=operator_codes)
     return list(operator_codes)

--- a/src/boilerplate/common_layer/xml/netex/helpers/helpers_service_frame.py
+++ b/src/boilerplate/common_layer/xml/netex/helpers/helpers_service_frame.py
@@ -2,7 +2,11 @@
 ServiceFrame Parsing Helpers
 """
 
+from structlog.stdlib import get_logger
+
 from ..models import Line, ServiceFrame
+
+log = get_logger()
 
 
 def get_lines_from_service_frames(frames: list[ServiceFrame]) -> list[Line]:
@@ -40,5 +44,5 @@ def get_atco_area_codes_from_service_frames(frames: list[ServiceFrame]) -> list[
             area_code = stop_point.atco_area_code
             if area_code and area_code.isdigit():
                 area_codes.add(int(area_code))
-
+    log.debug("Atco Area Codes found", area_codes=area_codes)
     return list(area_codes)

--- a/src/fares_etl/etl/app/etl_process.py
+++ b/src/fares_etl/etl/app/etl_process.py
@@ -34,7 +34,7 @@ def get_netex_publication_delivery(
     return xml
 
 
-@file_processing_result_to_db(step_name=StepName.ETL_PROCESS)
+@file_processing_result_to_db(step_name=StepName.FARES_ETL_PROCESS)
 def lambda_handler(event: dict[str, Any], _context: LambdaContext):
     """
     Fares ETL

--- a/src/fares_etl/etl/app/etl_process.py
+++ b/src/fares_etl/etl/app/etl_process.py
@@ -10,10 +10,8 @@ from aws_lambda_powertools.utilities.typing import LambdaContext
 from common_layer.db.constants import StepName
 from common_layer.db.file_processing_result import file_processing_result_to_db
 from common_layer.s3 import S3
-from common_layer.xml.netex.models.netex_publication_delivery import (
-    PublicationDeliveryStructure,
-)
-from common_layer.xml.netex.parser.netex_publication_delivery import parse_netex
+from common_layer.xml.netex.models import PublicationDeliveryStructure
+from common_layer.xml.netex.parser import parse_netex
 from structlog.stdlib import get_logger
 
 from .load.metadata import load_metadata_into_dynamodb

--- a/src/fares_etl/etl/app/load/metadata.py
+++ b/src/fares_etl/etl/app/load/metadata.py
@@ -7,9 +7,7 @@ from common_layer.dynamodb.client.fares_metadata import (
     DynamoDBFaresMetadata,
     FaresDynamoDBMetadataInput,
 )
-from common_layer.xml.netex.models.netex_publication_delivery import (
-    PublicationDeliveryStructure,
-)
+from common_layer.xml.netex.models import PublicationDeliveryStructure
 
 from ..transform.data_catalogue import create_data_catalogue
 from ..transform.metadata import create_metadata, get_stop_ids

--- a/src/fares_etl/etl/app/transform/data_catalogue.py
+++ b/src/fares_etl/etl/app/transform/data_catalogue.py
@@ -3,38 +3,31 @@ Create fares data catalogue
 """
 
 from common_layer.database.models import FaresDataCatalogueMetadata
-from common_layer.xml.netex.helpers.helpers_composite_frame import (
+from common_layer.xml.netex.helpers import (
+    get_atco_area_codes_from_service_frames,
     get_composite_frame_valid_from,
     get_composite_frame_valid_to,
-)
-from common_layer.xml.netex.helpers.helpers_counts import sort_frames
-from common_layer.xml.netex.helpers.helpers_fare_frame_fare_products import (
     get_fare_products,
+    get_line_ids_from_service_frames,
+    get_line_public_codes_from_service_frames,
+    get_national_operator_codes,
     get_product_names,
     get_product_types,
-)
-from common_layer.xml.netex.helpers.helpers_fare_frame_tariff import (
     get_tariff_basis,
     get_tariffs_from_fare_frames,
     get_user_types,
+    sort_frames,
 )
-from common_layer.xml.netex.helpers.helpers_resource_frame import (
-    get_national_operator_codes,
-)
-from common_layer.xml.netex.helpers.helpers_service_frame import (
-    get_atco_area_codes_from_service_frames,
-    get_line_ids_from_service_frames,
-    get_line_public_codes_from_service_frames,
-)
-from common_layer.xml.netex.models.netex_publication_delivery import (
-    PublicationDeliveryStructure,
-)
+from common_layer.xml.netex.models import PublicationDeliveryStructure
+from structlog.stdlib import get_logger
+
+log = get_logger()
 
 
 def create_data_catalogue(
     netex: PublicationDeliveryStructure,
     file_name: str,
-):
+) -> FaresDataCatalogueMetadata:
     """
     Create FaresDataCatalogueMetadata
     """
@@ -45,7 +38,7 @@ def create_data_catalogue(
     valid_from = get_composite_frame_valid_from(sorted_frames.composite_frames)
     valid_to = get_composite_frame_valid_to(sorted_frames.composite_frames)
 
-    return FaresDataCatalogueMetadata(
+    data_catalogue = FaresDataCatalogueMetadata(
         valid_from=valid_from.date() if valid_from else None,
         valid_to=valid_to.date() if valid_to else None,
         atco_area=get_atco_area_codes_from_service_frames(sorted_frames.service_frames),
@@ -62,3 +55,5 @@ def create_data_catalogue(
         user_type=get_user_types(tariffs),
         xml_file_name=file_name,
     )
+    log.info("Generated FearesDataCatalogueMetadata", **data_catalogue.as_dict())
+    return data_catalogue

--- a/src/fares_etl/etl/app/transform/metadata.py
+++ b/src/fares_etl/etl/app/transform/metadata.py
@@ -4,7 +4,12 @@ Create fares metadata
 
 from common_layer.database.models import FaresMetadata
 from common_layer.dynamodb.client import NaptanStopPointDynamoDBClient
-from common_layer.xml.netex.helpers.helpers_counts import (
+from common_layer.xml.netex.helpers import (
+    earliest_tariff_from_date,
+    get_fare_products,
+    get_scheduled_stop_point_refs,
+    get_tariffs_from_fare_frames,
+    latest_tariff_to_date,
     number_of_distinct_user_profiles,
     number_of_fare_zones,
     number_of_lines,
@@ -13,18 +18,10 @@ from common_layer.xml.netex.helpers.helpers_counts import (
     number_of_trip_fare_products,
     sort_frames,
 )
-from common_layer.xml.netex.helpers.helpers_fare_frame_fare_products import (
-    get_fare_products,
-)
-from common_layer.xml.netex.helpers.helpers_fare_frame_tariff import (
-    earliest_tariff_from_date,
-    get_tariffs_from_fare_frames,
-    latest_tariff_to_date,
-)
-from common_layer.xml.netex.helpers.helpers_fare_frame_zones import (
-    get_scheduled_stop_point_refs,
-)
 from common_layer.xml.netex.models import PublicationDeliveryStructure
+from structlog.stdlib import get_logger
+
+log = get_logger()
 
 
 def create_metadata(netex: PublicationDeliveryStructure) -> FaresMetadata:
@@ -35,8 +32,7 @@ def create_metadata(netex: PublicationDeliveryStructure) -> FaresMetadata:
 
     tariffs = get_tariffs_from_fare_frames(sorted_frames.fare_frames)
     fare_products = get_fare_products(sorted_frames.fare_frames)
-
-    return FaresMetadata(
+    fares_metadata = FaresMetadata(
         num_of_lines=number_of_lines(sorted_frames.service_frames),
         num_of_fare_zones=number_of_fare_zones(sorted_frames.fare_frames),
         num_of_sales_offer_packages=number_of_sales_offer_packages(
@@ -49,6 +45,8 @@ def create_metadata(netex: PublicationDeliveryStructure) -> FaresMetadata:
         valid_from=earliest_tariff_from_date(tariffs),
         valid_to=latest_tariff_to_date(tariffs),
     )
+    log.info("Created FaresMetadata", **fares_metadata.as_dict())
+    return fares_metadata
 
 
 def get_stop_ids(
@@ -78,5 +76,5 @@ def get_stop_ids(
         for stop in stops
         if stop.PrivateCode is not None and stop.PrivateCode.isdigit()
     }
-
+    log.info("Generated List of Stop Private Codes in Netex", stop_ids=stop_ids)
     return list(stop_ids)

--- a/src/fares_etl/metadata_aggregation/app/load/dataset.py
+++ b/src/fares_etl/metadata_aggregation/app/load/dataset.py
@@ -12,6 +12,9 @@ from common_layer.database.repos import (
     FaresValidationResultRepo,
     OrganisationDatasetMetdataRepo,
 )
+from structlog.stdlib import get_logger
+
+log = get_logger()
 
 
 def load_dataset(db: SqlDB, revision_id: int, schema_version: str) -> int:
@@ -32,6 +35,10 @@ def load_dataset(db: SqlDB, revision_id: int, schema_version: str) -> int:
     fares_validation_result_repo.delete_by_revision_id(revision_id)
 
     if metadata_id:
+        log.info(
+            "Metadata ID exists, deleting Fares Data Catalogue, Stops and Metadata by Id",
+            dataset_metadata_id=metadata_id,
+        )
         fares_data_catalogue_repo.delete_by_metadata_id(metadata_id)
         fares_metadata_stops_repo.delete_by_metadata_id(metadata_id)
         fares_metadata_repo.delete_by_metadata_id(metadata_id)
@@ -41,5 +48,8 @@ def load_dataset(db: SqlDB, revision_id: int, schema_version: str) -> int:
                 revision_id=revision_id, schema_version=schema_version
             )
         ).id
-
+    log.info(
+        "Dataset Loaded",
+        dataset_metadata_id=metadata_id,
+    )
     return metadata_id

--- a/src/fares_etl/metadata_aggregation/app/load/metadata.py
+++ b/src/fares_etl/metadata_aggregation/app/load/metadata.py
@@ -22,7 +22,10 @@ def load_metadata(
     data_catalogues: list[FaresDataCatalogueMetadata],
 ) -> None:
     """
-    Load metadata
+    Load metadata into:
+        - fares_faresmetadata
+        - fares_faresmetadata_stops
+        - fares_datacataloguemetadata
     """
     fares_metadata_repo = FaresMetadataRepo(db)
     fares_metadata_stops_repo = FaresMetadataStopsRepo(db)

--- a/src/fares_etl/metadata_aggregation/app/load/violations.py
+++ b/src/fares_etl/metadata_aggregation/app/load/violations.py
@@ -13,7 +13,11 @@ def load_violations(
     fares_validation_result: FaresValidationResult,
 ) -> None:
     """
-    Load metadata
+    Load Fares Validation Results
+
+    Tables:
+        - fares_validator_faresvalidation
+        - fares_validator_faresvalidationresult
     """
     fares_validation_repo = FaresValidationRepo(db)
     fares_validation_result_repo = FaresValidationResultRepo(db)

--- a/src/fares_etl/metadata_aggregation/app/metadata_aggregation.py
+++ b/src/fares_etl/metadata_aggregation/app/metadata_aggregation.py
@@ -15,9 +15,10 @@ from common_layer.database.repos import (
     OrganisationDatasetRepo,
     OrganisationDatasetRevisionRepo,
 )
+from common_layer.db.constants import StepName
+from common_layer.db.file_processing_result import file_processing_result_to_db
 from common_layer.dynamodb.client.fares_metadata import DynamoDBFaresMetadata
 from common_layer.exceptions import FaresMetadataNotFound
-from common_layer.json_logging import configure_logging
 from pydantic import BaseModel, Field
 from structlog.stdlib import get_logger
 
@@ -119,13 +120,13 @@ def load_metadata_to_database(
     load_metadata(db, aggregated_fares_metadata, stops, data_catalogues)
 
 
+@file_processing_result_to_db(step_name=StepName.FARES_METADATA_AGGREGATION)
 def lambda_handler(
-    event: dict[str, Any], context: LambdaContext
+    event: dict[str, Any], _context: LambdaContext
 ) -> dict[str, int | str]:
     """
     Fares Metadata Aggregation
     """
-    configure_logging(event, context)
 
     log.debug("Input Data", data=event)
     input_data = MetadataAggregationInputData(**event)

--- a/src/fares_etl/metadata_aggregation/app/transform/transform_metadata.py
+++ b/src/fares_etl/metadata_aggregation/app/transform/transform_metadata.py
@@ -2,6 +2,7 @@
 Transform fares metadata items
 """
 
+from dataclasses import asdict
 from typing import Any
 
 from boto3.dynamodb.types import TypeDeserializer
@@ -68,7 +69,7 @@ def aggregate_metadata(metadata_items: list[FaresMetadata]) -> FaresMetadata:
             or item.valid_to > aggregated_metadata.valid_to
         ):
             aggregated_metadata.valid_to = item.valid_to
-
+    log.info("Aggregated Metadata", **asdict(aggregated_metadata))
     return aggregated_metadata
 
 


### PR DESCRIPTION
Some discrepancies have been found with the existing setup, so this change adds extra logging

- Add FARES_ETL_PROCESS step name to differentiate from timetables
- Add file_processing_result_to_db decorator to FARES_METADATA_AGGREGATION
- Add netex helper functions to module's `__init__.py` to tidy up imports