### PR TITLE
fix(netex-parser): Parse timestamps without timezone as UTC

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: v1.0.148
+version: v1.0.149

--- a/src/boilerplate/common_layer/xml/netex/parser/netex_utility.py
+++ b/src/boilerplate/common_layer/xml/netex/parser/netex_utility.py
@@ -2,7 +2,7 @@
 Parsing Utilities
 """
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from lxml.etree import _Element  # type: ignore
 from structlog.stdlib import get_logger
@@ -80,8 +80,11 @@ def parse_timestamp(elem: _Element, element_name: str) -> datetime | None:
     """
     text = get_netex_text(elem, element_name)
     if text is not None:
-
-        return datetime.fromisoformat(text.replace("Z", "+00:00"))
+        dt = datetime.fromisoformat(text.replace("Z", "+00:00"))
+        # If the datetime is naive (no timezone info), assume UTC
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=UTC)
+        return dt
     return None
 
 

--- a/tests/fares_etl/etl/transform/test_metadata.py
+++ b/tests/fares_etl/etl/transform/test_metadata.py
@@ -1,3 +1,7 @@
+"""
+Tests for FaresMetadata construction
+"""
+
 import os
 from datetime import datetime, timezone
 from pathlib import Path
@@ -23,8 +27,8 @@ from fares_etl.etl.app.transform.metadata import create_metadata, get_stop_ids
                 num_of_sales_offer_packages=1,
                 num_of_trip_products=1,
                 num_of_user_profiles=1,
-                valid_from=datetime(2025, 1, 14, 0, 0),
-                valid_to=datetime(2125, 1, 14, 0, 0),
+                valid_from=datetime(2025, 1, 14, 0, 0, tzinfo=timezone.utc),
+                valid_to=datetime(2125, 1, 14, 0, 0, tzinfo=timezone.utc),
             ),
         ),
         pytest.param(
@@ -46,7 +50,10 @@ from fares_etl.etl.app.transform.metadata import create_metadata, get_stop_ids
 def test_extract_metadata(
     netex_file: str,
     expected_metadata: FaresMetadata,
-):
+) -> None:
+    """
+    Test extracting FaresMetadata from a file on disk
+    """
     netex = parse_netex(
         Path(os.path.dirname(__file__) + "/../../test_data/" + netex_file)
     )
@@ -228,7 +235,10 @@ def test_extract_stop_ids(
     netex_file: str,
     expected_atco_ids: list[str],
     expected_naptan_ids: list[str],
-):
+) -> None:
+    """
+    Test Extracting Stop Ids from a file on disk
+    """
     netex = parse_netex(
         Path(os.path.dirname(__file__) + "/../../test_data/" + netex_file)
     )

--- a/tests/xml/netex/conftest.py
+++ b/tests/xml/netex/conftest.py
@@ -4,7 +4,7 @@ Netex Fixtures / Utils
 
 from common_layer.xml.netex.parser import NETEX_NS
 from lxml import etree
-from lxml.etree import _Element
+from lxml.etree import _Element  # type: ignore
 
 
 def parse_xml_str_as_netex(xml_str: str) -> _Element:

--- a/tests/xml/netex/fare_frame/test_netex_fare_tariff.py
+++ b/tests/xml/netex/fare_frame/test_netex_fare_tariff.py
@@ -2,7 +2,7 @@
 Test Parsing a Tariff
 """
 
-from datetime import datetime
+from datetime import UTC, datetime
 
 import pytest
 from common_layer.xml.netex.models import (
@@ -58,8 +58,8 @@ from tests.xml.netex.conftest import parse_xml_str_as_netex
                 version="1.0",
                 validityConditions=[
                     FromToDate(
-                        FromDate=datetime(2025, 2, 5, 0, 0),
-                        ToDate=datetime(2125, 2, 5, 0, 0),
+                        FromDate=datetime(2025, 2, 5, 0, 0, tzinfo=UTC),
+                        ToDate=datetime(2125, 2, 5, 0, 0, tzinfo=UTC),
                     )
                 ],
                 Name=MultilingualString(

--- a/tests/xml/netex/test_netex_utility.py
+++ b/tests/xml/netex/test_netex_utility.py
@@ -5,7 +5,7 @@ Test Helper Functions
 from datetime import UTC, datetime, timedelta, timezone
 
 import pytest
-from common_layer.xml.netex.models.netex_utility import MultilingualString, VersionedRef
+from common_layer.xml.netex.models import MultilingualString, VersionedRef
 from common_layer.xml.netex.parser import parse_timestamp
 from common_layer.xml.netex.parser.netex_utility import (
     parse_multilingual_string,
@@ -64,11 +64,17 @@ from tests.xml.netex.conftest import (
             datetime(2024, 2, 14, 17, 30, 0, tzinfo=timezone(timedelta(hours=2))),
             id="Eastern European Time (EET)",
         ),
+        pytest.param(
+            """<Timestamp>2025-04-11T00:00:00</Timestamp>""",
+            "Timestamp",
+            datetime(2025, 4, 11, 0, 0, 0, tzinfo=UTC),
+            id="Timestamp without timezone info (assumed UTC)",
+        ),
     ],
 )
 def test_parse_timestamp(
     xml_str: str, element_name: str, expected_result: datetime | None
-):
+) -> None:
     """
     Test timestamp parsing for various formats and edge cases
     """

--- a/tests/xml/netex/test_scheduled_stop_point_ref.py
+++ b/tests/xml/netex/test_scheduled_stop_point_ref.py
@@ -37,8 +37,8 @@ from tests.xml.netex.conftest import parse_xml_str_as_netex
     ],
 )
 def test_scheduled_stop_point_reference_atco_code(
-    ref, version, name, expected_atco_code
-):
+    ref: str, version: str, name: str, expected_atco_code: str
+) -> None:
     """
     Test Parsing of the AtcoCodes
     """
@@ -61,8 +61,8 @@ def test_scheduled_stop_point_reference_atco_code(
     ],
 )
 def test_scheduled_stop_point_reference_incomplete_data(
-    ref, version, expected_atco_code
-):
+    ref: str, version: str, expected_atco_code: str
+) -> None:
     """
     Test Error case when it's not defined as atco code
     """
@@ -76,7 +76,9 @@ def test_scheduled_stop_point_reference_incomplete_data(
     [
         pytest.param(
             """
-            <ScheduledStopPointRef ref="atco:1000DINR5456" version="any">Brooke Street</ScheduledStopPointRef>
+            <ScheduledStopPointRef ref="atco:1000DINR5456" version="any">
+                Brooke Street
+            </ScheduledStopPointRef>
             """,
             ScheduledStopPointReference(
                 ref="atco:1000DINR5456",
@@ -124,8 +126,12 @@ def test_parse_scheduled_stop_point_ref(
         pytest.param(
             """
             <members>
-                <ScheduledStopPointRef ref="atco:1000DINR5456" version="any">Brooke Street</ScheduledStopPointRef>
-                <ScheduledStopPointRef ref="atco:1000DINR5491" version="any">Dale Street</ScheduledStopPointRef>
+                <ScheduledStopPointRef ref="atco:1000DINR5456" version="any">
+                    Brooke Street
+                </ScheduledStopPointRef>
+                <ScheduledStopPointRef ref="atco:1000DINR5491" version="any">
+                    Dale Street
+                </ScheduledStopPointRef>
                 <TimingPointRef ref="timing:123" version="1.0">Timing Point</TimingPointRef>
             </members>
             """,


### PR DESCRIPTION
Some netex files omit the Z or timezone identifier (+0000) so we can only assume it's in UTC

This may fix some comparison issues as this should ensure that all timezones in the parsed netex data are not naive

JIRA: https://kpmgengineering.atlassian.net/browse/BODS-8833
