### PR TITLE
tests(txc-parser): add types to test functions

### DIFF
--- a/tests/xml/conftest.py
+++ b/tests/xml/conftest.py
@@ -4,6 +4,7 @@ Fixtures / Helpers for XML Parsing
 
 import pytest
 from lxml import etree
+from lxml.etree import _Element  # type: ignore
 from pydantic import BaseModel
 from rich.pretty import pprint
 
@@ -37,7 +38,7 @@ def assert_model_equal(result: BaseModel, expected: BaseModel) -> None:
             raise e
 
 
-def compare_xml(result: etree._Element, expected: str):
+def compare_xml(result: _Element, expected: str):
     """
     Compare XML for Tests
     First converts to canonicalized form which standardises the output

--- a/tests/xml/txc/parser/test_txc_serviced_organisation.py
+++ b/tests/xml/txc/parser/test_txc_serviced_organisation.py
@@ -67,7 +67,9 @@ from tests.xml.conftest import assert_model_equal
         ),
     ],
 )
-def test_parse_date_range(xml_string, expected_result):
+def test_parse_date_range(
+    xml_string: str, expected_result: TXCServicedOrganisationDatePattern | None
+) -> None:
     """Test parsing of individual date range"""
     xml_element = etree.fromstring(xml_string)
     result = parse_date_range(xml_element)
@@ -144,7 +146,9 @@ def test_parse_date_range(xml_string, expected_result):
         ),
     ],
 )
-def test_parse_working_days(xml_string, expected_result):
+def test_parse_working_days(
+    xml_string: str, expected_result: list[TXCServicedOrganisationDatePattern] | None
+) -> None:
     """Test parsing of working days section"""
     xml_element = etree.fromstring(xml_string)
     result = parse_working_days(xml_element)
@@ -183,7 +187,9 @@ def test_parse_working_days(xml_string, expected_result):
         ),
     ],
 )
-def test_parse_holidays(xml_string, expected_result):
+def test_parse_holidays(
+    xml_string: str, expected_result: list[TXCServicedOrganisationDatePattern] | None
+) -> None:
     """Test parsing of holidays section"""
     xml_element = etree.fromstring(xml_string)
     result = parse_holidays(xml_element)
@@ -304,7 +310,9 @@ def test_parse_holidays(xml_string, expected_result):
         ),
     ],
 )
-def test_parse_serviced_organisation(xml_string, expected_result):
+def test_parse_serviced_organisation(
+    xml_string: str, expected_result: TXCServicedOrganisation | None
+) -> None:
     """Test parsing of serviced organisation"""
     xml_element = etree.fromstring(xml_string)
     result = parse_serviced_organisation(xml_element)

--- a/tests/xml/txc/parser/txc_journey_pattern_section/test_txc_journey_pattern_section.py
+++ b/tests/xml/txc/parser/txc_journey_pattern_section/test_txc_journey_pattern_section.py
@@ -155,7 +155,9 @@ from lxml import etree
         ),
     ],
 )
-def test_parse_journey_pattern_section(xml_string, expected_result):
+def test_parse_journey_pattern_section(
+    xml_string: str, expected_result: TXCJourneyPatternSection | None
+) -> None:
     """
     JPS Parsing tests
     """
@@ -346,7 +348,9 @@ def test_parse_journey_pattern_section(xml_string, expected_result):
         ),
     ],
 )
-def test_parse_journey_pattern_sections(xml_string, expected_result):
+def test_parse_journey_pattern_sections(
+    xml_string: str, expected_result: list[TXCJourneyPatternSection]
+) -> None:
     """
     Journey Pattern Sections Parsing
     """

--- a/tests/xml/txc/parser/txc_journey_pattern_section/test_txc_journey_pattern_timing_link.py
+++ b/tests/xml/txc/parser/txc_journey_pattern_section/test_txc_journey_pattern_timing_link.py
@@ -149,7 +149,9 @@ from lxml import etree
         ),
     ],
 )
-def test_parse_journey_pattern_timing_link(xml_string, expected_result):
+def test_parse_journey_pattern_timing_link(
+    xml_string: str, expected_result: TXCJourneyPatternTimingLink | None
+) -> None:
     """
     Timing Link Parsing
     """

--- a/tests/xml/txc/parser/txc_route_section/test_txc_route_section.py
+++ b/tests/xml/txc/parser/txc_route_section/test_txc_route_section.py
@@ -161,7 +161,7 @@ from lxml import etree
         ),
     ],
 )
-def test_parse_route_section(xml_string: str, expected: TXCRouteSection):
+def test_parse_route_section(xml_string: str, expected: TXCRouteSection) -> None:
     """
     Test the parsing of RouteSection from XML.
     """
@@ -476,7 +476,7 @@ def test_parse_route_section(xml_string: str, expected: TXCRouteSection):
         ),
     ],
 )
-def test_parse_route_sections(xml_string, expected):
+def test_parse_route_sections(xml_string: str, expected: list[TXCRouteSection]) -> None:
     """
     Test the parsing of RouteSection list from XML.
     """

--- a/tests/xml/txc/parser/txc_route_section/test_txc_route_section_location.py
+++ b/tests/xml/txc/parser/txc_route_section/test_txc_route_section_location.py
@@ -71,7 +71,7 @@ from lxml import etree
         ),
     ],
 )
-def test_parse_location(xml_string, expected):
+def test_parse_location(xml_string: str, expected: TXCLocation | None) -> None:
     """
     Test the parsing of TXCLocation from XML.
     """
@@ -158,7 +158,7 @@ def test_parse_location(xml_string, expected):
         ),
     ],
 )
-def test_parse_locations(xml_string, expected):
+def test_parse_locations(xml_string: str, expected: list[TXCLocation] | None):
     """
     Test the parsing of TXCLocation list from XML.
     """

--- a/tests/xml/txc/parser/txc_service/test_txc_service_journey_pattern.py
+++ b/tests/xml/txc/parser/txc_service/test_txc_service_journey_pattern.py
@@ -1,5 +1,5 @@
 """
-Test Parsing JourneyPattern in a TXC Service 
+Test Parsing JourneyPattern in a TXC Service
 """
 
 import pytest
@@ -57,7 +57,9 @@ from lxml import etree
         ),
     ],
 )
-def test_parse_journey_pattern(xml_string, expected_result):
+def test_parse_journey_pattern(
+    xml_string: str, expected_result: TXCJourneyPattern
+) -> None:
     """Test parsing of JourneyPattern section"""
     xml_element = etree.fromstring(xml_string)
     result = parse_journey_pattern(xml_element)

--- a/tests/xml/txc/parser/txc_service/test_txc_service_line.py
+++ b/tests/xml/txc/parser/txc_service/test_txc_service_line.py
@@ -52,7 +52,7 @@ from lxml import etree
         ),
     ],
 )
-def test_parse_line(xml_string, expected_result):
+def test_parse_line(xml_string: str, expected_result: TXCLine) -> None:
     """Test parsing of Line section"""
     xml_element = etree.fromstring(xml_string)
     result = parse_line(xml_element)

--- a/tests/xml/txc/parser/txc_service/test_txc_service_line_description.py
+++ b/tests/xml/txc/parser/txc_service/test_txc_service_line_description.py
@@ -87,7 +87,9 @@ from lxml import etree
         ),
     ],
 )
-def test_parse_line_description(xml_string, expected_result):
+def test_parse_line_description(
+    xml_string: str, expected_result: TXCLineDescription
+) -> None:
     """Test parsing of LineDescription section"""
     xml_element = etree.fromstring(xml_string)
     result = parse_line_description(xml_element)

--- a/tests/xml/txc/parser/txc_service/test_txc_service_standard_service.py
+++ b/tests/xml/txc/parser/txc_service/test_txc_service_standard_service.py
@@ -53,7 +53,9 @@ from lxml import etree
         ),
     ],
 )
-def test_parse_standard_service(xml_string, expected_result):
+def test_parse_standard_service(
+    xml_string: str, expected_result: TXCStandardService
+) -> None:
     """Test parsing of StandardService section"""
     xml_element = etree.fromstring(xml_string)
     result = parse_standard_service(xml_element)

--- a/tests/xml/txc/parser/txc_vehicle_journey/operating_profile/test_txc_operating_profile_periodic_days.py
+++ b/tests/xml/txc/parser/txc_vehicle_journey/operating_profile/test_txc_operating_profile_periodic_days.py
@@ -3,7 +3,7 @@ Test PeriodicDayType Parsing
 """
 
 import pytest
-from common_layer.xml.txc.models.txc_operating_profile import TXCPeriodicDayType
+from common_layer.xml.txc.models import TXCPeriodicDayType
 from common_layer.xml.txc.parser.operating_profile import parse_periodic_days
 from lxml import etree
 
@@ -52,7 +52,9 @@ from lxml import etree
         ),
     ],
 )
-def test_parse_periodic_days(xml_string, expected_result):
+def test_parse_periodic_days(
+    xml_string: str, expected_result: TXCPeriodicDayType
+) -> None:
     """
     Periodic dats parsing
     """

--- a/tests/xml/txc/parser/txc_vehicle_journey/test_txc_vehicle_journeys.py
+++ b/tests/xml/txc/parser/txc_vehicle_journey/test_txc_vehicle_journeys.py
@@ -75,7 +75,9 @@ from tests.xml.conftest import assert_model_equal
         ),
     ],
 )
-def test_parse_operational(xml_string, expected_result):
+def test_parse_operational(
+    xml_string: str, expected_result: TXCOperational | None
+) -> None:
     """
     Test Operational Section of Vehicle Journey parsing
     """
@@ -142,7 +144,9 @@ def test_parse_operational(xml_string, expected_result):
         ),
     ],
 )
-def test_parse_layover_point(xml_string, expected_result):
+def test_parse_layover_point(
+    xml_string: str, expected_result: TXCLayoverPoint | None
+) -> None:
     """
     Layover Points Parsing
     """
@@ -284,7 +288,9 @@ def test_parse_layover_point(xml_string, expected_result):
         ),
     ],
 )
-def test_parse_vehicle_journey(xml_string: str, expected_result: TXCVehicleJourney):
+def test_parse_vehicle_journey(
+    xml_string: str, expected_result: TXCVehicleJourney
+) -> None:
     """
     Parse XML for Vehicle Journey
     """
@@ -310,7 +316,7 @@ def test_parse_vehicle_journey(xml_string: str, expected_result: TXCVehicleJourn
         ),
     ],
 )
-def test_parse_vehicle_journey_exception(xml_string):
+def test_parse_vehicle_journey_exception(xml_string: str) -> None:
     """
     Parse XML for Vehicle Journey
     """

--- a/tests/xml/txc/parser/txc_vehicle_journey/test_txc_vehicle_journeys_flexible.py
+++ b/tests/xml/txc/parser/txc_vehicle_journey/test_txc_vehicle_journeys_flexible.py
@@ -140,7 +140,9 @@ from tests.xml.conftest import assert_model_equal
         ),
     ],
 )
-def test_parse_flexible_service_times(xml_string, expected_result):
+def test_parse_flexible_service_times(
+    xml_string: str, expected_result: list[TXCFlexibleServiceTimes] | None
+) -> None:
     """
     Test FlexibleServiceTimes section parsing including multiple service times
     """
@@ -277,7 +279,7 @@ def test_parse_flexible_vehicle_journey(
         ),
     ],
 )
-def test_parse_flexible_vehicle_journey_validation_error(xml_string):
+def test_parse_flexible_vehicle_journey_validation_error(xml_string: str) -> None:
     """
     Test FlexibleVehicleJourney validation errors
     """

--- a/tests/xml/txc/parser/txc_vehicle_journey/test_txc_vehicle_journeys_timing_links.py
+++ b/tests/xml/txc/parser/txc_vehicle_journey/test_txc_vehicle_journeys_timing_links.py
@@ -71,7 +71,9 @@ from lxml import etree
         ),
     ],
 )
-def test_parse_vehicle_journey_stop_usage(xml_string, expected_result):
+def test_parse_vehicle_journey_stop_usage(
+    xml_string: str, expected_result: TXCVehicleJourneyStopUsageStructure | None
+) -> None:
     """
     Test parsing of VehicleJourneyStopUsageStructure (From/To) section
     """
@@ -109,7 +111,9 @@ def test_parse_vehicle_journey_stop_usage(xml_string, expected_result):
         ),
     ],
 )
-def test_parse_vehicle_journey_timing_link(xml_string, expected_result):
+def test_parse_vehicle_journey_timing_link(
+    xml_string: str, expected_result: TXCVehicleJourneyTimingLink
+) -> None:
     """
     Test parsing of VehicleJourneyTimingLink section
     """
@@ -162,7 +166,9 @@ def test_parse_vehicle_journey_timing_link(xml_string, expected_result):
         ),
     ],
 )
-def test_parse_vehicle_journey_timing_links(xml_string, expected_result):
+def test_parse_vehicle_journey_timing_links(
+    xml_string: str, expected_result: list[TXCVehicleJourneyTimingLink]
+) -> None:
     """
     Test parsing of all VehicleJourneyTimingLink sections
     """


### PR DESCRIPTION
Fix strict linting complaints about unknown type inputs on paratermerised tests

