### PR TITLE
fix(fares-aggregation): Calculate unique counts for User Profiles, Trip and Pass products

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: v1.0.150
+version: v1.0.151

--- a/src/fares_etl/metadata_aggregation/app/metadata_aggregation.py
+++ b/src/fares_etl/metadata_aggregation/app/metadata_aggregation.py
@@ -103,12 +103,12 @@ def load_metadata_to_database(
     stops: list[FaresMetadataStop],
     data_catalogues: list[FaresDataCatalogueMetadata],
     metadata_dataset_id: int,
-):
+) -> None:
     """
     Write metadata to database
     """
 
-    aggregated_fares_metadata = aggregate_metadata(metadata)
+    aggregated_fares_metadata = aggregate_metadata(metadata, data_catalogues)
     aggregated_fares_metadata.datasetmetadata_ptr_id = metadata_dataset_id
 
     for data_catalogue in data_catalogues:

--- a/tests/fares_etl/metadata_aggregation/transform/test_transform_metadata.py
+++ b/tests/fares_etl/metadata_aggregation/transform/test_transform_metadata.py
@@ -1,11 +1,12 @@
-from datetime import datetime
+from datetime import date, datetime
 
 import pytest
-from common_layer.database.models import FaresMetadata
+from common_layer.database.models import FaresDataCatalogueMetadata, FaresMetadata
 
 from fares_etl.metadata_aggregation.app.transform.transform_metadata import (
     aggregate_metadata,
     get_min_schema_version,
+    sum_metadata_fields,
 )
 
 
@@ -23,6 +24,91 @@ def test_get_min_schema_version(
     min_schema_version = get_min_schema_version(schema_versions)
 
     assert min_schema_version == expected_min_schema_version
+
+
+@pytest.mark.parametrize(
+    "metadata,data_catalogues,expected_aggregated_metadata",
+    [
+        pytest.param(
+            [
+                FaresMetadata(
+                    num_of_fare_products=2,
+                    num_of_fare_zones=1,
+                    num_of_lines=0,
+                    num_of_pass_products=3,
+                    num_of_sales_offer_packages=8,
+                    num_of_trip_products=1,
+                    num_of_user_profiles=0,
+                    valid_from=datetime(2025, 1, 1, 23, 30, 10),
+                    valid_to=datetime(2026, 12, 12, 12, 10, 0),
+                )
+            ],
+            [],
+            FaresMetadata(
+                num_of_fare_products=2,
+                num_of_fare_zones=1,
+                num_of_lines=0,
+                num_of_pass_products=0,
+                num_of_sales_offer_packages=8,
+                num_of_trip_products=0,
+                num_of_user_profiles=0,
+                valid_from=datetime(2025, 1, 1, 23, 30, 10),
+                valid_to=datetime(2026, 12, 12, 12, 10, 0),
+            ),
+            id="Single metadata item with empty data catalogues",
+        ),
+        pytest.param(
+            [
+                FaresMetadata(
+                    num_of_fare_products=2,
+                    num_of_fare_zones=1,
+                    num_of_lines=0,
+                    num_of_pass_products=3,
+                    num_of_sales_offer_packages=8,
+                    num_of_trip_products=1,
+                    num_of_user_profiles=0,
+                    valid_from=datetime(2025, 1, 1, 23, 30, 10),
+                    valid_to=datetime(2026, 12, 12, 12, 10, 0),
+                ),
+                FaresMetadata(
+                    num_of_fare_products=4,
+                    num_of_fare_zones=6,
+                    num_of_lines=1,
+                    num_of_pass_products=8,
+                    num_of_sales_offer_packages=2,
+                    num_of_trip_products=4,
+                    num_of_user_profiles=2,
+                    valid_from=datetime(2024, 11, 1, 23, 30, 10),
+                    valid_to=datetime(2025, 12, 12, 12, 10, 0),
+                ),
+            ],
+            [],  # Empty data_catalogues
+            FaresMetadata(
+                num_of_fare_products=6,
+                num_of_fare_zones=7,
+                num_of_lines=1,
+                num_of_pass_products=0,
+                num_of_sales_offer_packages=10,
+                num_of_trip_products=0,
+                num_of_user_profiles=0,
+                valid_from=datetime(2024, 11, 1, 23, 30, 10),
+                valid_to=datetime(2026, 12, 12, 12, 10, 0),
+            ),
+            id="Multiple metadata items with empty data catalogues",
+        ),
+    ],
+)
+def test_aggregate_metadata(
+    metadata: list[FaresMetadata],
+    data_catalogues: list[FaresDataCatalogueMetadata],
+    expected_aggregated_metadata: FaresMetadata,
+) -> None:
+    """
+    Test generating the aggregate metadata
+    """
+    aggregated_metadata = aggregate_metadata(metadata, data_catalogues)
+
+    assert aggregated_metadata == expected_aggregated_metadata
 
 
 @pytest.mark.parametrize(
@@ -46,13 +132,14 @@ def test_get_min_schema_version(
                 num_of_fare_products=2,
                 num_of_fare_zones=1,
                 num_of_lines=0,
-                num_of_pass_products=3,
+                num_of_pass_products=0,
                 num_of_sales_offer_packages=8,
-                num_of_trip_products=1,
+                num_of_trip_products=0,
                 num_of_user_profiles=0,
                 valid_from=datetime(2025, 1, 1, 23, 30, 10),
                 valid_to=datetime(2026, 12, 12, 12, 10, 0),
             ),
+            id="Sum single metadata item fields",
         ),
         pytest.param(
             [
@@ -83,20 +170,97 @@ def test_get_min_schema_version(
                 num_of_fare_products=6,
                 num_of_fare_zones=7,
                 num_of_lines=1,
-                num_of_pass_products=11,
+                num_of_pass_products=0,
                 num_of_sales_offer_packages=10,
-                num_of_trip_products=5,
-                num_of_user_profiles=2,
+                num_of_trip_products=0,
+                num_of_user_profiles=0,
                 valid_from=datetime(2024, 11, 1, 23, 30, 10),
                 valid_to=datetime(2026, 12, 12, 12, 10, 0),
             ),
+            id="Sum multiple metadata item fields with date range calculation",
         ),
     ],
 )
-def test_aggregate_metadata(
+def test_sum_metadata_fields(
     metadata: list[FaresMetadata],
     expected_aggregated_metadata: FaresMetadata,
-):
-    aggregated_metadata = aggregate_metadata(metadata)
+) -> None:
+    """
+    Test summing metadata fields
+    """
+    aggregated_metadata = sum_metadata_fields(metadata)
+
+    assert aggregated_metadata == expected_aggregated_metadata
+
+
+@pytest.mark.parametrize(
+    "metadata,data_catalogues,expected_aggregated_metadata",
+    [
+        pytest.param(
+            [
+                FaresMetadata(
+                    num_of_fare_products=2,
+                    num_of_fare_zones=1,
+                    num_of_lines=0,
+                    num_of_pass_products=3,
+                    num_of_sales_offer_packages=8,
+                    num_of_trip_products=1,
+                    num_of_user_profiles=0,
+                    valid_from=datetime(2025, 1, 1, 23, 30, 10),
+                    valid_to=datetime(2026, 12, 12, 12, 10, 0),
+                )
+            ],
+            [
+                FaresDataCatalogueMetadata(
+                    xml_file_name="file1.xml",
+                    valid_from=date(2025, 1, 1),
+                    valid_to=date(2026, 12, 12),
+                    national_operator_code=["NOC1"],
+                    line_id=["LINE1"],
+                    line_name=["Line 1"],
+                    atco_area=[1],
+                    tariff_basis=["zone"],
+                    product_type=["dayPass", "singleTrip"],
+                    product_name=["Day Pass", "Single Trip"],
+                    user_type=["adult", "child"],
+                ),
+                FaresDataCatalogueMetadata(
+                    xml_file_name="file2.xml",
+                    valid_from=date(2024, 11, 1),
+                    valid_to=date(2025, 12, 12),
+                    national_operator_code=["NOC2"],
+                    line_id=["LINE2"],
+                    line_name=["Line 2"],
+                    atco_area=[2],
+                    tariff_basis=["pointToPoint"],
+                    product_type=["periodPass", "dayReturnTrip"],
+                    product_name=["Period Pass", "Day Return Trip"],
+                    user_type=["adult", "senior"],
+                ),
+            ],
+            FaresMetadata(
+                num_of_fare_products=2,
+                num_of_fare_zones=1,
+                num_of_lines=0,
+                num_of_pass_products=2,  # dayPass, periodPass
+                num_of_sales_offer_packages=8,
+                num_of_trip_products=2,  # singleTrip, dayReturnTrip
+                num_of_user_profiles=3,  # adult, child, senior
+                valid_from=datetime(2025, 1, 1, 23, 30, 10),
+                valid_to=datetime(2026, 12, 12, 12, 10, 0),
+            ),
+            id="Calculate unique counts from data catalogues",
+        ),
+    ],
+)
+def test_aggregate_metadata_with_data_catalogues(
+    metadata: list[FaresMetadata],
+    data_catalogues: list[FaresDataCatalogueMetadata],
+    expected_aggregated_metadata: FaresMetadata,
+) -> None:
+    """
+    Test generating the aggregate metadata with data catalogues
+    """
+    aggregated_metadata = aggregate_metadata(metadata, data_catalogues)
 
     assert aggregated_metadata == expected_aggregated_metadata


### PR DESCRIPTION
It turns out that that duplicates are being counted but we should be able to calculate the unique items using the FaresDataCatalogueMetadata object that populates the fares_datacataloguemetadata table in the ETL process

JIRA: https://kpmgengineering.atlassian.net/browse/BODS-8832