### PR TITLE
fix(netex-parser): assume Europe/London instead of UTC for timestamps without Timezone

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: v1.0.151
+version: v1.0.152

--- a/tests/xml/netex/test_netex_utility.py
+++ b/tests/xml/netex/test_netex_utility.py
@@ -3,6 +3,7 @@ Test Helper Functions
 """
 
 from datetime import UTC, datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
 
 import pytest
 from common_layer.xml.netex.models import MultilingualString, VersionedRef
@@ -67,8 +68,14 @@ from tests.xml.netex.conftest import (
         pytest.param(
             """<Timestamp>2025-04-11T00:00:00</Timestamp>""",
             "Timestamp",
-            datetime(2025, 4, 11, 0, 0, 0, tzinfo=UTC),
-            id="Timestamp without timezone info (assumed UTC)",
+            datetime(2025, 4, 11, 0, 0, 0, tzinfo=ZoneInfo("Europe/London")),
+            id="Timestamp without timezone info in BST (assumed Europe/London)",
+        ),
+        pytest.param(
+            """<Timestamp>2025-01-15T12:00:00</Timestamp>""",
+            "Timestamp",
+            datetime(2025, 1, 15, 12, 0, 0, tzinfo=UTC),
+            id="Timestamp without timezone info in GMT (assumed Europe/London)",
         ),
     ],
 )


### PR DESCRIPTION
Bods is configured to use Europe/London as the timezone when adding items into the DB

This means that dates without timezones will need to parsed as Europe/London to correctly have the right date in them.

- Default missing timezones to Europe/London using ZoneInfo
- Add test cases for BST (hour shift) and GMT


JIRA: https://kpmgengineering.atlassian.net/browse/BODS-8833
