### PR TITLE
feat(logging): add LOG_LEVEL env var and default to INFO

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: v1.0.154
+version: v1.0.155

--- a/fares-etl.yaml
+++ b/fares-etl.yaml
@@ -110,6 +110,7 @@ Globals:
         DD_RUNTIME_METRICS_ENABLED: true
         DD_DBM_PROPAGATION_MODE: full
         DD_EXTENSION_VERSION: compatibility
+        LOG_LEVEL: INFO
 
 Resources:
   #######################

--- a/periodic-tasks.yaml
+++ b/periodic-tasks.yaml
@@ -83,6 +83,7 @@ Globals:
           - !Ref AWS::NoValue
         DD_EXTENSION_VERSION: compatibility
         NO_PROXY: 'localhost,127.0.0.1,secretsmanager.eu-west-2.amazonaws.com,s3.eu-west-2.amazonaws.com,dynamodb.eu-west-2.amazonaws.com,instrumentation-telemetry-intake.datadoghq.eu,7-63-3-app.agent.datadoghq.eu,http-intake.logs.datadoghq.eu,trace.agent.datadoghq.eu'
+        LOG_LEVEL: INFO
     KmsKeyArn: !If
       - IsNotLocal
       - !Sub '{{resolve:ssm:/bodds/${Environment}/kms-key-arn}}'

--- a/src/boilerplate/common_layer/json_logging.py
+++ b/src/boilerplate/common_layer/json_logging.py
@@ -112,7 +112,7 @@ def get_log_level() -> int:
     log_level_int = log_level_map.get(log_level_str, logging.DEBUG)
     logger = structlog.stdlib.get_logger()
     logger.info(
-        "Logging Configured", log_level_int=log_level_int, log_level_str=log_level_str
+        "Log Level Determined", log_level_int=log_level_int, log_level_str=log_level_str
     )
     return log_level_int
 

--- a/timetables-etl.yaml
+++ b/timetables-etl.yaml
@@ -113,6 +113,7 @@ Globals:
         DD_RUNTIME_METRICS_ENABLED: true
         DD_DBM_PROPAGATION_MODE: full
         DD_EXTENSION_VERSION: compatibility
+        LOG_LEVEL: INFO
 
 Resources:
   #######################


### PR DESCRIPTION
Rather than always logging at DEBUG level, we should default to INFO
By using an env var it means that we can selectively change the logging level
