### PR TITLE
fix(netex-parser): Parse PublicationRefreshInterval as ISO 8601 duration

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: v1.0.153
+version: v1.0.154

--- a/src/boilerplate/common_layer/xml/netex/parser/netex_publication_delivery.py
+++ b/src/boilerplate/common_layer/xml/netex/parser/netex_publication_delivery.py
@@ -5,6 +5,7 @@ Parser for Top Level PublicationDelivery
 from io import BytesIO
 from pathlib import Path
 
+from common_layer.xml.utils import parse_duration
 from lxml.etree import _Element  # type: ignore
 from structlog.stdlib import get_logger
 
@@ -17,7 +18,6 @@ from .netex_utility import (
     get_netex_element,
     get_netex_text,
     parse_multilingual_string,
-    parse_timedelta,
     parse_timestamp,
 )
 
@@ -47,7 +47,9 @@ def parse_publication_delivery(elem: _Element) -> PublicationDeliveryStructure:
         else None
     )
 
-    refresh_interval = parse_timedelta(elem, "PublicationRefreshInterval")
+    refresh_interval = parse_duration(
+        get_netex_text(elem, "PublicationRefreshInterval")
+    )
 
     description = parse_multilingual_string(elem, "Description")
 

--- a/src/boilerplate/common_layer/xml/utils/__init__.py
+++ b/src/boilerplate/common_layer/xml/utils/__init__.py
@@ -3,6 +3,7 @@ Exports
 """
 
 from .hashing import get_bytes_hash, get_file_hash
+from .xml_duration import parse_duration
 from .xml_utils import find_section, load_xml_tree
 from .xml_utils_attributes import (
     parse_creation_datetime,
@@ -52,4 +53,6 @@ __all__ = [
     # Hashing Functions
     "get_file_hash",
     "get_bytes_hash",
+    # Timedelta Duration
+    "parse_duration",
 ]

--- a/src/boilerplate/common_layer/xml/utils/xml_duration.py
+++ b/src/boilerplate/common_layer/xml/utils/xml_duration.py
@@ -1,0 +1,41 @@
+"""
+Time Duration Parsing
+"""
+
+import re
+from datetime import timedelta
+
+DURATION_PATTERN = re.compile(
+    r"(-)?P(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?)?"
+)
+
+
+def parse_duration(duration: str | None) -> timedelta:
+    """
+    Convert ISO 8601 duration to timedelta, returns 0 if None
+    Handles negative durations, decimal seconds, and days
+    """
+    if not duration:
+        return timedelta(0)
+
+    match = DURATION_PATTERN.match(duration)
+    if not match:
+        return timedelta(0)
+
+    sign = -1 if match.group(1) else 1
+    days = int(match.group(2) or 0)
+    hours = int(match.group(3) or 0)
+    minutes = int(match.group(4) or 0)
+
+    seconds_str = match.group(5) or "0"
+    seconds_float = float(seconds_str)
+    seconds = int(seconds_float)
+    microseconds = int((seconds_float - seconds) * 1_000_000)
+
+    return sign * timedelta(
+        days=days,
+        hours=hours,
+        minutes=minutes,
+        seconds=seconds,
+        microseconds=microseconds,
+    )

--- a/src/timetables_etl/etl/app/transform/service_pattern_stops_durations.py
+++ b/src/timetables_etl/etl/app/transform/service_pattern_stops_durations.py
@@ -2,7 +2,6 @@
 Handling Journey Durations and WaitTimes
 """
 
-import re
 from datetime import timedelta
 
 from common_layer.xml.txc.models import (
@@ -11,33 +10,12 @@ from common_layer.xml.txc.models import (
     TXCVehicleJourney,
     TXCVehicleJourneyTimingLink,
 )
+from common_layer.xml.utils import parse_duration
 from structlog.stdlib import get_logger
 
 from .models_context import LinkContext
 
 log = get_logger()
-
-
-DURATION_PATTERN = re.compile(r"PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?")
-
-
-def parse_duration(duration: str | None) -> timedelta:
-    """
-    Convert ISO 8601 duration to timedelta, returns 0 if None
-    Compiling the regex pattern outside of the function is about 10x faster
-    """
-    if not duration:
-        return timedelta(0)
-
-    match = DURATION_PATTERN.match(duration)
-    if not match:
-        return timedelta(0)
-
-    hours = int(match.group(1) or 0)
-    minutes = int(match.group(2) or 0)
-    seconds = int(match.group(3) or 0)
-
-    return timedelta(hours=hours, minutes=minutes, seconds=seconds)
 
 
 def apply_wait_time_rules(

--- a/tests/timetables_etl/etl/transform/test_service_pattern_stops_time.py
+++ b/tests/timetables_etl/etl/transform/test_service_pattern_stops_time.py
@@ -10,50 +10,6 @@ from timetables_etl.etl.app.transform.service_pattern_stops import (
     calculate_next_time,
     parse_time,
 )
-from timetables_etl.etl.app.transform.service_pattern_stops_durations import (
-    parse_duration,
-)
-
-
-@pytest.mark.parametrize(
-    "duration_str,expected",
-    [
-        pytest.param(
-            "PT1H30M",
-            timedelta(hours=1, minutes=30),
-            id="Hours and minutes",
-        ),
-        pytest.param(
-            "PT45M",
-            timedelta(minutes=45),
-            id="Minutes only",
-        ),
-        pytest.param(
-            "PT2H",
-            timedelta(hours=2),
-            id="Hours only",
-        ),
-        pytest.param(
-            "PT1H20M30S",
-            timedelta(hours=1, minutes=20, seconds=30),
-            id="Hours, minutes and seconds",
-        ),
-        pytest.param(
-            None,
-            timedelta(0),
-            id="None returns zero duration",
-        ),
-        pytest.param(
-            "invalid",
-            timedelta(0),
-            id="Invalid format returns zero duration",
-        ),
-    ],
-)
-def test_parse_duration(duration_str: str | None, expected: timedelta) -> None:
-    """Test parsing of ISO 8601 duration strings"""
-    result = parse_duration(duration_str)
-    assert result == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/xml/utils/test_xml_duration.py
+++ b/tests/xml/utils/test_xml_duration.py
@@ -1,0 +1,84 @@
+"""
+Test Duration Parsing
+"""
+
+from datetime import timedelta
+
+import pytest
+from common_layer.xml.utils import parse_duration
+
+
+@pytest.mark.parametrize(
+    "duration_str,expected",
+    [
+        pytest.param(
+            "PT1H30M",
+            timedelta(hours=1, minutes=30),
+            id="Hours and minutes",
+        ),
+        pytest.param(
+            "PT45M",
+            timedelta(minutes=45),
+            id="Minutes only",
+        ),
+        pytest.param(
+            "PT2H",
+            timedelta(hours=2),
+            id="Hours only",
+        ),
+        pytest.param(
+            "PT1H20M30S",
+            timedelta(hours=1, minutes=20, seconds=30),
+            id="Hours, minutes and seconds",
+        ),
+        pytest.param(
+            None,
+            timedelta(0),
+            id="None returns zero duration",
+        ),
+        pytest.param(
+            "invalid",
+            timedelta(0),
+            id="Invalid format returns zero duration",
+        ),
+        pytest.param(
+            "-PT1H30M",
+            timedelta(hours=-1, minutes=-30),
+            id="Negative hours and minutes",
+        ),
+        pytest.param(
+            "-PT45M",
+            timedelta(minutes=-45),
+            id="Negative minutes only",
+        ),
+        pytest.param(
+            "-PT1H20M30S",
+            timedelta(hours=-1, minutes=-20, seconds=-30),
+            id="Negative hours, minutes and seconds",
+        ),
+        pytest.param(
+            "PT1M30.5S",
+            timedelta(minutes=1, seconds=30, microseconds=500000),
+            id="Decimal seconds",
+        ),
+        pytest.param(
+            "PT0.5S",
+            timedelta(microseconds=500000),
+            id="Decimal seconds only",
+        ),
+        pytest.param(
+            "P0D",
+            timedelta(0),
+            id="Zero days",
+        ),
+        pytest.param(
+            "PT0S",
+            timedelta(0),
+            id="Zero seconds",
+        ),
+    ],
+)
+def test_parse_duration(duration_str: str | None, expected: timedelta) -> None:
+    """Test parsing of ISO 8601 duration strings"""
+    result = parse_duration(duration_str)
+    assert result == expected

--- a/tools/file_viewer/txc/tabs/journey_pattern_sections/tab_jps.py
+++ b/tools/file_viewer/txc/tabs/journey_pattern_sections/tab_jps.py
@@ -9,16 +9,13 @@ from common_layer.xml.txc.models import (
     TXCJourneyPatternTimingLink,
     TXCRouteLink,
 )
+from common_layer.xml.utils import parse_duration
 from textual import on
 from textual.app import ComposeResult
 from textual.containers import Container, Horizontal, ScrollableContainer, Vertical
 from textual.css.query import NoMatches
 from textual.reactive import Reactive, reactive
 from textual.widgets import DataTable, Static
-
-from src.timetables_etl.etl.app.transform.service_pattern_stops_durations import (
-    parse_duration,
-)
 
 from ...utils_stoppoints import get_stop_point_details
 from .tab_jps_tables import (

--- a/tools/file_viewer/txc/tabs/vehicle_journeys/tab_vehicle_journeys.py
+++ b/tools/file_viewer/txc/tabs/vehicle_journeys/tab_vehicle_journeys.py
@@ -13,16 +13,13 @@ from common_layer.xml.txc.models import (
     TXCVehicleJourney,
     TXCVehicleJourneyTimingLink,
 )
+from common_layer.xml.utils import parse_duration
 from textual import on
 from textual.app import ComposeResult
 from textual.containers import Container, Horizontal, ScrollableContainer, Vertical
 from textual.css.query import NoMatches
 from textual.reactive import Reactive, reactive
 from textual.widgets import DataTable, Static
-
-from src.timetables_etl.etl.app.transform.service_pattern_stops_durations import (
-    parse_duration,
-)
 
 from ...utils_stoppoints import StopPointDetails, get_stop_point_details
 from .tab_vehicle_journeys_tables import (


### PR DESCRIPTION
The value in that section of the Netex document is not parsable as a timedelta but instead requires parsing as an ISO duration

- Move parse_duration into shared xml utils
- Update with test cases for negative durations and days

JIRA: https://kpmgengineering.atlassian.net/browse/BODS-8930
