### PR TITLE
fix(NaptanCacheStateMachine): Update naptan population schedule + add retries

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: v1.0.154
+version: v1.0.155

--- a/periodic-tasks.yaml
+++ b/periodic-tasks.yaml
@@ -166,8 +166,8 @@ Resources:
           Type: Schedule
           Properties:
             Name: !Sub '${ProjectName}-${Environment}-${SubFunction}-naptan-cache-sm-daily'
-            Description: 'Trigger Naptan cache update state machine every 24 hours'
-            Schedule: 'rate(24 hours)'
+            Description: 'Trigger Naptan cache update state machine every day at 1am UTC'
+            Schedule: 'cron(0 1 * * ? *)'
             Input: !Sub |
               {
                 "naptan_url": "https://naptan.api.dft.gov.uk/v1/access-nodes?dataFormat=xml",
@@ -189,8 +189,12 @@ Resources:
               'max_concurrent_batches.$': '$.max_concurrent_batches'
               'write_mode.$': '$.write_mode'
             ResultPath: '$.populate_result'
+            Retry:
+              - ErrorEquals: ['States.ALL']
+                IntervalSeconds: 0
+                MaxAttempts: 3
             Catch:
-              - ErrorEquals: ['States.TaskFailed']
+              - ErrorEquals: ['States.ALL']
                 Next: FailureState
             Next: UpdateIDsDynamodbNaptanCache
           UpdateIDsDynamodbNaptanCache:

--- a/periodic-tasks.yaml
+++ b/periodic-tasks.yaml
@@ -190,11 +190,11 @@ Resources:
               'write_mode.$': '$.write_mode'
             ResultPath: '$.populate_result'
             Retry:
-              - ErrorEquals: ['States.ALL']
+              - ErrorEquals: ['Lambda.Unknown']
                 IntervalSeconds: 0
                 MaxAttempts: 3
             Catch:
-              - ErrorEquals: ['States.ALL']
+              - ErrorEquals: ['States.TaskFailed']
                 Next: FailureState
             Next: UpdateIDsDynamodbNaptanCache
           UpdateIDsDynamodbNaptanCache:


### PR DESCRIPTION
Scheduling Naptan Cache State Machine to run at 1am UTC every night (instead of every 24hrs from deploy time) and add retries to reduce risk in the case of timeouts.

Jira Issue: https://kpmgengineering.atlassian.net/browse/BODS-8934