### PR TITLE
fix: include different fare product types and lines in counts

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: v1.0.157
+version: v1.0.158

--- a/src/boilerplate/common_layer/xml/netex/helpers/__init__.py
+++ b/src/boilerplate/common_layer/xml/netex/helpers/__init__.py
@@ -10,6 +10,7 @@ from .helpers_composite_frame import (
 )
 from .helpers_counts import (
     number_of_distinct_user_profiles,
+    number_of_fare_products,
     number_of_fare_zones,
     number_of_lines,
     number_of_pass_fare_products,
@@ -48,6 +49,7 @@ __all__ = [
     "number_of_pass_fare_products",
     "number_of_sales_offer_packages",
     "number_of_trip_fare_products",
+    "number_of_fare_products",
     "sort_frames",
     # From helpers_fare_frame_fare_products
     "get_fare_products",

--- a/src/boilerplate/common_layer/xml/netex/helpers/helpers_counts.py
+++ b/src/boilerplate/common_layer/xml/netex/helpers/helpers_counts.py
@@ -12,7 +12,6 @@ from .helpers_fare_frame_fare_products import get_product_types
 from .helpers_fare_frame_sales_offer_packages import get_sales_offer_packages
 from .helpers_fare_frame_tariff import get_user_types
 from .helpers_fare_frame_zones import get_fare_zones
-from .helpers_service_frame import get_lines_from_service_frames
 
 
 class SortedFrames(BaseModel):
@@ -56,8 +55,7 @@ def number_of_lines(frames: list[ServiceFrame]) -> int:
     """
     Number of Lines in a Netex Doc
     """
-    lines = get_lines_from_service_frames(frames)
-    return len(lines)
+    return sum(frame.numOfLines for frame in frames)
 
 
 def number_of_fare_zones(frames: list[FareFrame]) -> int:
@@ -109,3 +107,12 @@ def number_of_sales_offer_packages(frames: list[FareFrame]) -> int:
     Number of sales offer packages
     """
     return len(get_sales_offer_packages(frames))
+
+
+def number_of_fare_products(
+    fare_frames: list[FareFrame],
+) -> int:
+    """
+    Get number of fare products across all Fare Frames
+    """
+    return sum(frame.numOfFareProducts for frame in fare_frames)

--- a/src/boilerplate/common_layer/xml/netex/models/data_objects/netex_frame_service.py
+++ b/src/boilerplate/common_layer/xml/netex/models/data_objects/netex_frame_service.py
@@ -120,3 +120,8 @@ class ServiceFrame(BaseModel):
     scheduledStopPoints: Annotated[
         list[ScheduledStopPoint], Field(description="List of scheduled stop points")
     ]
+
+    numOfLines: Annotated[
+        int,
+        Field(description="Number of lines in the service frame", default=0),
+    ]

--- a/src/boilerplate/common_layer/xml/netex/models/fare_frame/netex_frame_fare.py
+++ b/src/boilerplate/common_layer/xml/netex/models/fare_frame/netex_frame_fare.py
@@ -198,3 +198,6 @@ class FareFrame(BaseModel):
         list[SalesOfferPackage] | None,
         Field(description="list of sales offer packages", default=None),
     ]
+    numOfFareProducts: Annotated[
+        int, Field(description="Number of fare products", default=0)
+    ]

--- a/src/boilerplate/common_layer/xml/netex/parser/data_objects/netex_frame_service.py
+++ b/src/boilerplate/common_layer/xml/netex/parser/data_objects/netex_frame_service.py
@@ -108,6 +108,7 @@ def parse_service_frame(elem: _Element) -> ServiceFrame:
 
     # Parse lists
     lines = get_netex_element(elem, "lines")
+    num_of_lines = len(lines) if lines is not None else 0
     parsed_lines = parse_lines(lines) if lines is not None else []
 
     stop_points = get_netex_element(elem, "scheduledStopPoints")
@@ -124,4 +125,5 @@ def parse_service_frame(elem: _Element) -> ServiceFrame:
         TypeOfFrameRef=type_of_frame_ref,
         lines=parsed_lines,
         scheduledStopPoints=parsed_stop_points,
+        numOfLines=num_of_lines,
     )

--- a/src/boilerplate/common_layer/xml/netex/parser/fare_frame/netex_frame_fare.py
+++ b/src/boilerplate/common_layer/xml/netex/parser/fare_frame/netex_frame_fare.py
@@ -61,7 +61,7 @@ class FareFrameCoreAttributes:
 
 
 @dataclass
-class FareFrameContent:
+class FareFrameContent:  # pylint: disable=too-many-instance-attributes
     """
     Complex Context
     """
@@ -73,6 +73,7 @@ class FareFrameContent:
     tariffs: list[Tariff]
     fare_zones: list[FareZone]
     sales_offer_packages: list[SalesOfferPackage]
+    num_of_fare_products: int
 
 
 def parse_fare_frame_core_attributes(elem: _Element) -> FareFrameCoreAttributes:
@@ -95,6 +96,7 @@ def parse_fare_frame_content(elem: _Element) -> FareFrameContent:
         tariffs=[],
         fare_zones=[],
         sales_offer_packages=[],
+        num_of_fare_products=0,
     )
 
     for child in elem:
@@ -107,6 +109,7 @@ def parse_fare_frame_content(elem: _Element) -> FareFrameContent:
             case "fareTables":
                 content.fare_tables = parse_fare_tables(child)
             case "fareProducts":
+                content.num_of_fare_products = len(child)
                 content.fare_products = parse_preassigned_fare_products(child)
             case "tariffs":
                 content.tariffs = parse_tariffs(child)
@@ -152,4 +155,5 @@ def parse_fare_frame(elem: _Element) -> FareFrame:
         salesOfferPackages=(
             content.sales_offer_packages if content.sales_offer_packages else None
         ),
+        numOfFareProducts=content.num_of_fare_products,
     )

--- a/src/fares_etl/etl/app/transform/metadata.py
+++ b/src/fares_etl/etl/app/transform/metadata.py
@@ -11,6 +11,7 @@ from common_layer.xml.netex.helpers import (
     get_tariffs_from_fare_frames,
     latest_tariff_to_date,
     number_of_distinct_user_profiles,
+    number_of_fare_products,
     number_of_fare_zones,
     number_of_lines,
     number_of_pass_fare_products,
@@ -38,7 +39,7 @@ def create_metadata(netex: PublicationDeliveryStructure) -> FaresMetadata:
         num_of_sales_offer_packages=number_of_sales_offer_packages(
             sorted_frames.fare_frames
         ),
-        num_of_fare_products=len(fare_products),
+        num_of_fare_products=number_of_fare_products(sorted_frames.fare_frames),
         num_of_user_profiles=number_of_distinct_user_profiles(tariffs),
         num_of_pass_products=number_of_pass_fare_products(fare_products),
         num_of_trip_products=number_of_trip_fare_products(fare_products),

--- a/tests/fares_etl/etl/transform/test_metadata.py
+++ b/tests/fares_etl/etl/transform/test_metadata.py
@@ -20,7 +20,7 @@ from fares_etl.etl.app.transform.metadata import create_metadata, get_stop_ids
         pytest.param(
             "netex1.xml",
             FaresMetadata(
-                num_of_fare_products=1,
+                num_of_fare_products=2,
                 num_of_fare_zones=28,
                 num_of_lines=1,
                 num_of_pass_products=0,
@@ -36,7 +36,7 @@ from fares_etl.etl.app.transform.metadata import create_metadata, get_stop_ids
             FaresMetadata(
                 num_of_fare_products=1,
                 num_of_fare_zones=8,
-                num_of_lines=1,
+                num_of_lines=2,
                 num_of_pass_products=0,
                 num_of_sales_offer_packages=2,
                 num_of_trip_products=1,

--- a/tests/fares_etl/test_data/netex1.xml
+++ b/tests/fares_etl/test_data/netex1.xml
@@ -5280,6 +5280,24 @@
                             </accessRightsInProduct>
                             <ProductType>dayReturnTrip</ProductType>
                         </PreassignedFareProduct>
+                        <CappedDiscountRight id="op:Cap:@trip" version="1.0">
+                            <Name>Cap noc:FSYO</Name>
+                            <cappingRules>
+                                <CappingRule version="1.0" id="op:Tap_and_Cap_Day@flatFare_trip">
+                                    <Name>Tap and Cap Day</Name>
+                                    <CappingPeriod>day</CappingPeriod>
+                                    <ValidableElementRef version="1.0"
+                                        ref="Trip@ADRTN@travel" />
+                                    <GenericParameterAssignment version="1.0"
+                                        id="Tap_and_Cap_Day@Flat_Single"
+                                        order="1">
+                                        <Name>limit a adult to 1 day</Name>
+                                        <PreassignedFareProductRef version="1.0"
+                                            ref="Trip@ADRTN" />
+                                    </GenericParameterAssignment>
+                                </CappingRule>
+                            </cappingRules>
+                        </CappedDiscountRight>
                     </fareProducts>
                     <salesOfferPackages>
                         <SalesOfferPackage id="Trip@ADRTN-SOP@Onboard" version="1.0">

--- a/tests/fares_etl/test_data/netex2.xml
+++ b/tests/fares_etl/test_data/netex2.xml
@@ -149,6 +149,9 @@
                             <OperatorRef version="1.0" ref="noc:LNUD">noc:136947</OperatorRef>
                             <LineType>local</LineType>
                         </Line>
+                        <FlexibleLine version="1.0" id="LNUD:PC0005248:1:152:Flex">
+                            <Name>Flexible</Name>
+                        </FlexibleLine>
                     </lines>
                     <scheduledStopPoints>
                         <ScheduledStopPoint version="any" id="atco:2500JB78">


### PR DESCRIPTION
Include different fare product types (eg. CappedDiscountRights) and different lines (eg. FlexibleLines) in the metadata counts.

JIRA: https://kpmgengineering.atlassian.net/browse/BODS-8960
