### PR TITLE
feat(ETL): Bods 9044/historical tracks data

### DIFF
--- a/src/boilerplate/common_layer/database/models/__init__.py
+++ b/src/boilerplate/common_layer/database/models/__init__.py
@@ -22,6 +22,7 @@ from .model_junction import (
     OrganisationDatasetRevisionLocalities,
     TransmodelServicePatternAdminAreas,
     TransmodelServicePatternLocality,
+    TransmodelServicePatternTracks,
     TransmodelServiceServicePattern,
     TransmodelTracksVehicleJourney,
 )
@@ -134,4 +135,5 @@ __all__ = [
     "TransmodelServicePatternLocality",
     "TransmodelServiceServicePattern",
     "TransmodelTracksVehicleJourney",
+    "TransmodelServicePatternTracks",
 ]

--- a/src/boilerplate/common_layer/database/models/model_junction.py
+++ b/src/boilerplate/common_layer/database/models/model_junction.py
@@ -137,7 +137,7 @@ class TransmodelServicePatternTracks(BaseSQLModel):
     Represents which Tracks are used by which Service Patterns in sequence
     """
 
-    __tablename__ = "transmodel_servicepattern_tracks"
+    __tablename__ = "transmodel_servicepatterntracks"
 
     id: Mapped[int] = mapped_column(
         Integer, primary_key=True, init=False, autoincrement=True

--- a/src/boilerplate/common_layer/database/models/model_junction.py
+++ b/src/boilerplate/common_layer/database/models/model_junction.py
@@ -129,3 +129,29 @@ class TransmodelTracksVehicleJourney(BaseSQLModel):
         ),
         nullable=False,
     )
+
+
+class TransmodelServicePatternTracks(BaseSQLModel):
+    """
+    Association table between Tracks and Service Patterns
+    Represents which Tracks are used by which Service Patterns in sequence
+    """
+
+    __tablename__ = "transmodel_servicepattern_tracks"
+
+    id: Mapped[int] = mapped_column(
+        Integer, primary_key=True, init=False, autoincrement=True
+    )
+    sequence_number: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    tracks_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("transmodel_tracks.id", deferrable=True, initially="DEFERRED"),
+        nullable=False,
+    )
+    service_pattern_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey(
+            "transmodel_servicepattern.id", deferrable=True, initially="DEFERRED"
+        ),
+        nullable=False,
+    )

--- a/src/boilerplate/common_layer/database/models/model_organisation.py
+++ b/src/boilerplate/common_layer/database/models/model_organisation.py
@@ -104,8 +104,12 @@ class OrganisationDatasetRevision(TimeStampedMixin, BaseSQLModel):
     num_of_timing_points: Mapped[int | None] = mapped_column(Integer, nullable=True)
     modified_file_hash: Mapped[str] = mapped_column(String(40), nullable=False)
     original_file_hash: Mapped[str] = mapped_column(String(40), nullable=False)
-    modified_before_reprocessing: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
-    status_before_reprocessing: Mapped[str] = mapped_column(String(20), nullable=False, default="")
+    modified_before_reprocessing: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    status_before_reprocessing: Mapped[str] = mapped_column(
+        String(20), nullable=False, default=""
+    )
 
 
 class OrganisationDatasetMetadata(BaseSQLModel):

--- a/src/boilerplate/common_layer/database/models/model_organisation.py
+++ b/src/boilerplate/common_layer/database/models/model_organisation.py
@@ -104,6 +104,8 @@ class OrganisationDatasetRevision(TimeStampedMixin, BaseSQLModel):
     num_of_timing_points: Mapped[int | None] = mapped_column(Integer, nullable=True)
     modified_file_hash: Mapped[str] = mapped_column(String(40), nullable=False)
     original_file_hash: Mapped[str] = mapped_column(String(40), nullable=False)
+    modified_before_reprocessing: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    status_before_reprocessing: Mapped[str] = mapped_column(String(20), nullable=False, default="")
 
 
 class OrganisationDatasetMetadata(BaseSQLModel):

--- a/src/boilerplate/common_layer/database/repos/__init__.py
+++ b/src/boilerplate/common_layer/database/repos/__init__.py
@@ -26,6 +26,7 @@ from .repo_junction import (
     OrganisationDatasetRevisionLocalitiesRepo,
     TransmodelServicePatternAdminAreaRepo,
     TransmodelServicePatternLocalityRepo,
+    TransmodelServicePatternTracksRepo,
     TransmodelServiceServicePatternRepo,
     TransmodelTracksVehicleJourneyRepo,
 )
@@ -119,4 +120,5 @@ __all__ = [
     "TransmodelOperatingDatesExceptionsRepo",
     "TransmodelOperatingProfileRepo",
     "TransmodelVehicleJourneyRepo",
+    "TransmodelServicePatternTracksRepo",
 ]

--- a/src/boilerplate/common_layer/database/repos/repo_junction.py
+++ b/src/boilerplate/common_layer/database/repos/repo_junction.py
@@ -12,6 +12,7 @@ from ..models import (
     TransmodelServicePattern,
     TransmodelServicePatternAdminAreas,
     TransmodelServicePatternLocality,
+    TransmodelServicePatternTracks,
     TransmodelServiceServicePattern,
     TransmodelTracksVehicleJourney,
 )
@@ -284,3 +285,12 @@ class TransmodelTracksVehicleJourneyRepo(
             self._model.vehicle_journey_id.in_(vehicle_journey_ids)
         )
         return self._fetch_all(statement)
+
+
+class TransmodelServicePatternTracksRepo(
+    BaseRepository[TransmodelServicePatternTracks]
+):
+    """Repository for managing Tracks to Service Pattern associations"""
+
+    def __init__(self, db: SqlDB):
+        super().__init__(db, TransmodelServicePatternTracks)

--- a/src/boilerplate/common_layer/database/repos/repo_transmodel.py
+++ b/src/boilerplate/common_layer/database/repos/repo_transmodel.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from datetime import date
 from typing import Literal
 
-from sqlalchemy import func, select, text, tuple_
+from sqlalchemy import func, select, tuple_
 from sqlalchemy.dialects.postgresql import insert
 
 from ..client import SqlDB

--- a/src/boilerplate/common_layer/database/repos/repo_transmodel.py
+++ b/src/boilerplate/common_layer/database/repos/repo_transmodel.py
@@ -239,13 +239,13 @@ class TransmodelTrackRepo(BaseRepositoryWithId[TransmodelTracks]):
             return bool(result)
 
     @handle_repository_errors
-    def bulk_insert_ignore_duplicates(self, records: list[TransmodelTracks]) -> None:
+    def bulk_insert_ignore_duplicates(self, records: list[TransmodelTracks]) -> dict[tuple[str, str], int]:
         """
         Insert multiple records using PostgreSQL's ON CONFLICT DO NOTHING syntax.
         Returns count of records inserted
         """
         if not records:
-            return
+            return {}
 
         with self._db.session_scope() as session:
             insert_stmt = insert(self._model)
@@ -253,7 +253,8 @@ class TransmodelTrackRepo(BaseRepositoryWithId[TransmodelTracks]):
                 insert_stmt = insert_stmt.on_conflict_do_nothing(
                     index_elements=["from_atco_code", "to_atco_code"]
                 )
-
+            insert_stmt = insert_stmt.returning(self._model.id, self._model.from_atco_code, self._model.to_atco_code)
             records_to_create = [record.__dict__ for record in records]
-            session.execute(insert_stmt, records_to_create)
-        return
+            results = session.execute(insert_stmt, records_to_create)
+            tracks = {(row[1], row[2]): row[0]  for row in results.fetchall()}
+            return tracks

--- a/src/boilerplate/common_layer/database/repos/repo_transmodel.py
+++ b/src/boilerplate/common_layer/database/repos/repo_transmodel.py
@@ -239,7 +239,9 @@ class TransmodelTrackRepo(BaseRepositoryWithId[TransmodelTracks]):
             return bool(result)
 
     @handle_repository_errors
-    def bulk_insert_ignore_duplicates(self, records: list[TransmodelTracks]) -> dict[tuple[str, str], int]:
+    def bulk_insert_ignore_duplicates(
+        self, records: list[TransmodelTracks]
+    ) -> dict[tuple[str, str], int]:
         """
         Insert multiple records using PostgreSQL's ON CONFLICT DO NOTHING syntax.
         Returns count of records inserted
@@ -253,8 +255,10 @@ class TransmodelTrackRepo(BaseRepositoryWithId[TransmodelTracks]):
                 insert_stmt = insert_stmt.on_conflict_do_nothing(
                     index_elements=["from_atco_code", "to_atco_code"]
                 )
-            insert_stmt = insert_stmt.returning(self._model.id, self._model.from_atco_code, self._model.to_atco_code)
+            insert_stmt = insert_stmt.returning(
+                self._model.id, self._model.from_atco_code, self._model.to_atco_code
+            )
             records_to_create = [record.__dict__ for record in records]
             results = session.execute(insert_stmt, records_to_create)
-            tracks = {(row[1], row[2]): row[0]  for row in results.fetchall()}
+            tracks = {(row[1], row[2]): row[0] for row in results.fetchall()}
             return tracks

--- a/src/timetables_etl/etl/app/load/service_pattern_tracks.py
+++ b/src/timetables_etl/etl/app/load/service_pattern_tracks.py
@@ -1,0 +1,34 @@
+"""
+Process and add Vehicle Journey Tracks to DB
+"""
+
+from common_layer.database.client import SqlDB
+from common_layer.database.models import NaptanStopPoint, TransmodelServicePatternTracks
+from common_layer.database.repos import TransmodelServicePatternTracksRepo
+from common_layer.xml.txc.models import TXCFlexibleJourneyPattern, TXCJourneyPattern
+from structlog.stdlib import get_logger
+
+from ..helpers import TrackLookup
+from ..transform.service_pattern_tracks import generate_service_pattern_tracks
+
+log = get_logger()
+
+
+def load_service_pattern_tracks(
+    journey_pattern: TXCJourneyPattern | TXCFlexibleJourneyPattern,
+    service_pattern_id: int,
+    track_lookup: TrackLookup,
+    stop_sequence: list[NaptanStopPoint],
+    db: SqlDB,
+) -> list[TransmodelServicePatternTracks]:
+    """
+    Generate Vehicle Journey Tracks
+    """
+    sp_tracks = generate_service_pattern_tracks(
+        journey_pattern, service_pattern_id, track_lookup, stop_sequence
+    )
+
+    result = TransmodelServicePatternTracksRepo(db).bulk_insert(sp_tracks)
+
+    log.info("Added SP to Track Links to Database", count=len(result))
+    return result

--- a/src/timetables_etl/etl/app/load/servicepatterns_common.py
+++ b/src/timetables_etl/etl/app/load/servicepatterns_common.py
@@ -41,6 +41,7 @@ from .models_context import (
     ServicePatternMapping,
     ServicePatternVehicleJourneyContext,
 )
+from .service_pattern_tracks import load_service_pattern_tracks
 from .vehicle_journey import (
     load_vehicle_journey_tracks,
     process_service_pattern_vehicle_journeys,
@@ -232,12 +233,9 @@ def process_pattern_common(
         vj_context,
     )
 
-    # This is where we create the links between Tracks and Vehicle Journeys
-    # We now want to create the link between service pattern and the tracks instead
-    # Link context.service_pattern.service_pattern_id -> tracks
-    tracks = load_vehicle_journey_tracks(
+    tracks = load_service_pattern_tracks(
         reference_journey_pattern,
-        tm_vjs,
+        context.service_pattern.id,
         context.lookups.tracks,
         sp_data.stop_sequence,
         context.db,

--- a/src/timetables_etl/etl/app/load/servicepatterns_common.py
+++ b/src/timetables_etl/etl/app/load/servicepatterns_common.py
@@ -232,6 +232,9 @@ def process_pattern_common(
         vj_context,
     )
 
+    # This is where we create the links between Tracks and Vehicle Journeys
+    # We now want to create the link between service pattern and the tracks instead
+    # Link context.service_pattern.service_pattern_id -> tracks
     tracks = load_vehicle_journey_tracks(
         reference_journey_pattern,
         tm_vjs,

--- a/src/timetables_etl/etl/app/load/servicepatterns_common.py
+++ b/src/timetables_etl/etl/app/load/servicepatterns_common.py
@@ -43,7 +43,6 @@ from .models_context import (
 )
 from .service_pattern_tracks import load_service_pattern_tracks
 from .vehicle_journey import (
-    load_vehicle_journey_tracks,
     process_service_pattern_vehicle_journeys,
 )
 

--- a/src/timetables_etl/etl/app/load/tracks.py
+++ b/src/timetables_etl/etl/app/load/tracks.py
@@ -16,6 +16,7 @@ from ..transform.tracks import create_new_tracks
 
 log = get_logger()
 
+
 def load_tracks(route_sections: list[TXCRouteSection], db: SqlDB) -> TrackLookup:
     """
     Process tracks from route sections, creating new ones if they don't exist.
@@ -32,4 +33,14 @@ def load_tracks(route_sections: list[TXCRouteSection], db: SqlDB) -> TrackLookup
         new_tracks_count=len(new_tracks),
     )
 
-    return {(track.from_atco_code, track.to_atco_code): (setattr(track, "id", track_ids.get((track.from_atco_code, track.to_atco_code), None)) or track) for track in new_tracks}
+    return {
+        (track.from_atco_code, track.to_atco_code): (
+            setattr(
+                track,
+                "id",
+                track_ids.get((track.from_atco_code, track.to_atco_code), None),
+            )
+            or track
+        )
+        for track in new_tracks
+    }

--- a/src/timetables_etl/etl/app/load/tracks.py
+++ b/src/timetables_etl/etl/app/load/tracks.py
@@ -11,7 +11,7 @@ from common_layer.xml.txc.models import TXCRouteSection
 from structlog.stdlib import get_logger
 
 from ..helpers import TrackLookup
-from ..transform.tracks import analyze_track_pairs, create_new_tracks
+from ..transform.tracks import create_new_tracks
 
 log = get_logger()
 
@@ -22,23 +22,14 @@ def load_tracks(route_sections: list[TXCRouteSection], db: SqlDB) -> TrackLookup
     Returns a lookup dictionary mapping (from_atco, to_atco) to TransmodelTracks
     """
     log_ctx = log.bind()
-    track_repo = TransmodelTrackRepo(db)
     route_pairs = extract_stop_point_pairs_from_route_sections(route_sections)
+    new_tracks = create_new_tracks(route_pairs, route_sections)
 
-    existing_tracks = track_repo.get_by_stop_pairs(route_pairs)
-    analysis = analyze_track_pairs(route_pairs, existing_tracks)
+    track_repo = TransmodelTrackRepo(db)
+    track_repo.bulk_insert_ignore_duplicates(new_tracks)
+    log_ctx.info(
+        "Added new tracks to database",
+        new_tracks_count=len(new_tracks),
+    )
 
-    all_tracks = existing_tracks
-    if analysis.pairs_to_create:
-        new_tracks = create_new_tracks(analysis.pairs_to_create, route_sections)
-        track_repo.bulk_insert_ignore_duplicates(new_tracks)
-        all_tracks = track_repo.get_by_stop_pairs(route_pairs)
-
-        log_ctx.info(
-            "Fetched Existing and Added new tracks to database",
-            new_tracks_count=len(new_tracks),
-            existing_tracks=len(existing_tracks),
-            total_tracks=len(all_tracks),
-        )
-
-    return {(track.from_atco_code, track.to_atco_code): track for track in all_tracks}
+    return {(track.from_atco_code, track.to_atco_code): track for track in new_tracks}

--- a/src/timetables_etl/etl/app/load/tracks.py
+++ b/src/timetables_etl/etl/app/load/tracks.py
@@ -3,11 +3,7 @@ Tracks Generation
 """
 
 from common_layer.database import SqlDB
-from common_layer.database.models.model_transmodel import TransmodelTracks
 from common_layer.database.repos import TransmodelTrackRepo
-from common_layer.xml.txc.helpers.routes import (
-    extract_stop_point_pairs_from_route_sections,
-)
 from common_layer.xml.txc.models import TXCRouteSection
 from structlog.stdlib import get_logger
 

--- a/src/timetables_etl/etl/app/load/tracks.py
+++ b/src/timetables_etl/etl/app/load/tracks.py
@@ -3,6 +3,7 @@ Tracks Generation
 """
 
 from common_layer.database import SqlDB
+from common_layer.database.models.model_transmodel import TransmodelTracks
 from common_layer.database.repos import TransmodelTrackRepo
 from common_layer.xml.txc.helpers.routes import (
     extract_stop_point_pairs_from_route_sections,
@@ -15,7 +16,6 @@ from ..transform.tracks import create_new_tracks
 
 log = get_logger()
 
-
 def load_tracks(route_sections: list[TXCRouteSection], db: SqlDB) -> TrackLookup:
     """
     Process tracks from route sections, creating new ones if they don't exist.
@@ -25,10 +25,11 @@ def load_tracks(route_sections: list[TXCRouteSection], db: SqlDB) -> TrackLookup
     new_tracks = create_new_tracks(route_sections)
 
     track_repo = TransmodelTrackRepo(db)
-    track_repo.bulk_insert_ignore_duplicates(new_tracks)
+    track_ids = track_repo.bulk_insert_ignore_duplicates(new_tracks)
+
     log_ctx.info(
         "Added new tracks to database",
         new_tracks_count=len(new_tracks),
     )
 
-    return {(track.from_atco_code, track.to_atco_code): track for track in new_tracks}
+    return {(track.from_atco_code, track.to_atco_code): (setattr(track, "id", track_ids.get((track.from_atco_code, track.to_atco_code), None)) or track) for track in new_tracks}

--- a/src/timetables_etl/etl/app/load/tracks.py
+++ b/src/timetables_etl/etl/app/load/tracks.py
@@ -22,8 +22,7 @@ def load_tracks(route_sections: list[TXCRouteSection], db: SqlDB) -> TrackLookup
     Returns a lookup dictionary mapping (from_atco, to_atco) to TransmodelTracks
     """
     log_ctx = log.bind()
-    route_pairs = extract_stop_point_pairs_from_route_sections(route_sections)
-    new_tracks = create_new_tracks(route_pairs, route_sections)
+    new_tracks = create_new_tracks(route_sections)
 
     track_repo = TransmodelTrackRepo(db)
     track_repo.bulk_insert_ignore_duplicates(new_tracks)

--- a/src/timetables_etl/etl/app/transform/service_pattern_tracks.py
+++ b/src/timetables_etl/etl/app/transform/service_pattern_tracks.py
@@ -1,0 +1,81 @@
+
+"""
+Vehicle Journey Tracks Generation
+"""
+
+from common_layer.database.models import (
+    NaptanStopPoint,
+    TransmodelServicePatternTracks,
+)
+from common_layer.xml.txc.helpers.routes import extract_stop_point_pairs
+from common_layer.xml.txc.models import TXCFlexibleJourneyPattern, TXCJourneyPattern
+from structlog.stdlib import get_logger
+
+from ..helpers import TrackLookup
+
+log = get_logger()
+
+
+def generate_standard_service_tracks(
+    journey_pattern: TXCJourneyPattern,
+    service_pattern_id: int,
+    stop_sequence: list[NaptanStopPoint],
+    track_lookup: TrackLookup,
+) -> list[TransmodelServicePatternTracks]:
+    """
+    Generate the tracks for a StandardService
+    """
+    log_ctx = log.bind(
+        journey_pattern_id=journey_pattern.id,
+    )
+    ordered_pairs = extract_stop_point_pairs(stop_sequence)
+    sp_tracks: list[TransmodelServicePatternTracks] = []
+
+    for sequence_number, (from_code, to_code) in enumerate(ordered_pairs):
+        track = track_lookup.get((from_code, to_code))
+        if track:
+            sp_tracks.append(
+                TransmodelServicePatternTracks(
+                    sequence_number=sequence_number,
+                    tracks_id=track.id,
+                    service_pattern_id=service_pattern_id,
+                )
+            )
+
+    log_ctx.info(
+        "Generated service pattern tracks",
+        tracks_created=len(sp_tracks),
+        stop_sequence_count=len(stop_sequence),
+    )
+
+    return sp_tracks
+
+
+def generate_flexible_service_tracks(_journey_pattern: TXCFlexibleJourneyPattern):
+    """
+    Generate the tracks for a StandardService
+    """
+    log.error("Flexible Service Tracks Not Implemented!")
+
+def generate_service_pattern_tracks(
+    journey_pattern: TXCJourneyPattern | TXCFlexibleJourneyPattern,
+    service_pattern_id:int,
+    track_lookup: TrackLookup,
+    stop_sequence: list[NaptanStopPoint],
+) -> list[TransmodelServicePatternTracks]:
+    """
+    Create Vehicle Journey Tracks
+    """
+    match journey_pattern:
+        case TXCJourneyPattern():
+            return generate_standard_service_tracks(
+                journey_pattern=journey_pattern,
+                service_pattern_id=service_pattern_id,
+                stop_sequence=stop_sequence,
+                track_lookup=track_lookup,
+            )
+        case TXCFlexibleJourneyPattern():
+            generate_flexible_service_tracks(journey_pattern)
+            return []
+        case _:
+            raise ValueError(f"Unknown Journey Pattern type: {type(journey_pattern)}")

--- a/src/timetables_etl/etl/app/transform/service_pattern_tracks.py
+++ b/src/timetables_etl/etl/app/transform/service_pattern_tracks.py
@@ -1,4 +1,3 @@
-
 """
 Vehicle Journey Tracks Generation
 """
@@ -57,9 +56,10 @@ def generate_flexible_service_tracks(_journey_pattern: TXCFlexibleJourneyPattern
     """
     log.error("Flexible Service Tracks Not Implemented!")
 
+
 def generate_service_pattern_tracks(
     journey_pattern: TXCJourneyPattern | TXCFlexibleJourneyPattern,
-    service_pattern_id:int,
+    service_pattern_id: int,
     track_lookup: TrackLookup,
     stop_sequence: list[NaptanStopPoint],
 ) -> list[TransmodelServicePatternTracks]:

--- a/src/timetables_etl/etl/app/transform/tracks.py
+++ b/src/timetables_etl/etl/app/transform/tracks.py
@@ -129,16 +129,15 @@ def create_track_mapping(
     Create a mapping from (from_code, to_code) pairs to their corresponding
     Track and Distance information.
     """
-    all_route_links = [
-        route_link for section in route_sections for route_link in section.RouteLink
+
+    route_links_with_track = [
+        route_link
+        for section in route_sections
+        for route_link in section.RouteLink
+        if route_link.Track
     ]
-
-    total_links = len(all_route_links)
-    links_with_track = sum(1 for route_link in all_route_links if route_link.Track)
-    links_without_track = total_links - links_with_track
-
     track_mapping: dict[tuple[str, str], tuple[TXCTrack, int | None]] = {}
-    for route_link in all_route_links:
+    for route_link in route_links_with_track:
         if route_link.Track:
             track_mapping[(route_link.From, route_link.To)] = (
                 route_link.Track,
@@ -147,13 +146,8 @@ def create_track_mapping(
 
     log.info(
         "Created track mapping",
-        total_route_links=total_links,
-        links_with_track=links_with_track,
-        links_without_track=links_without_track,
         total_mappings=len(track_mapping),
-        duplicate_pairs_with_track=links_with_track - len(track_mapping),
     )
-
     return track_mapping
 
 

--- a/src/timetables_etl/etl/app/transform/tracks.py
+++ b/src/timetables_etl/etl/app/transform/tracks.py
@@ -191,6 +191,9 @@ def create_new_tracks(route_sections: list[TXCRouteSection]) -> list[TransmodelT
         total_tracks=len(new_tracks),
         with_geometry=sum(1 for t in new_tracks if t.geometry is not None),
         with_distance=sum(1 for t in new_tracks if t.distance is not None),
+    )
+    log.debug(
+        "Stop point pairs for inserted tracks",
         new_atco_pairs=[(t.from_atco_code, t.to_atco_code) for t in new_tracks],
     )
 

--- a/tests/factories/database/organisation.py
+++ b/tests/factories/database/organisation.py
@@ -95,6 +95,8 @@ class OrganisationDatasetRevisionFactory(factory.Factory):
     modified = LazyFunction(lambda: datetime.now(UTC))
     modified_file_hash = factory.Faker("sha1")
     original_file_hash = factory.Faker("sha1")
+    modified_before_reprocessing = None
+    status_before_reprocessing = ""
 
     @classmethod
     def create_with_id(cls, id_number: int, **kwargs) -> OrganisationDatasetRevision:

--- a/tests/factories/database/transmodel.py
+++ b/tests/factories/database/transmodel.py
@@ -9,9 +9,15 @@ import factory
 from common_layer.database.models import (
     TransmodelBookingArrangements,
     TransmodelService,
+    TransmodelServicePattern,
     TransmodelServicePatternStop,
+    TransmodelTracks,
     TransmodelVehicleJourney,
 )
+from geoalchemy2.shape import from_shape
+from shapely.geometry import LineString as ShapelyLineString
+
+from .organisation import OrganisationDatasetRevisionFactory
 
 
 class TransmodelVehicleJourneyFactory(factory.Factory):
@@ -177,3 +183,19 @@ class TransmodelServicePatternStopFactory(factory.Factory):
     vehicle_journey_id = None
     stop_activity_id = None
     auto_sequence_number = factory.SelfAttribute("sequence_number")
+
+
+class TransmodelTracksFactory(factory.Factory):
+    """Factory for TransmodelTracks"""
+
+    class Meta: # type: ignore[misc]
+        model = TransmodelTracks
+
+    from_atco_code = factory.Faker("ATCO001")
+    to_atco_code = factory.Faker("ATCO001")
+    geometry = factory.LazyFunction(lambda: from_shape(
+        ShapelyLineString([(0, 0), (1, 1), (2, 2)]),
+        srid=4326
+    ))
+    distance = 10
+

--- a/tests/factories/database/transmodel.py
+++ b/tests/factories/database/transmodel.py
@@ -188,14 +188,12 @@ class TransmodelServicePatternStopFactory(factory.Factory):
 class TransmodelTracksFactory(factory.Factory):
     """Factory for TransmodelTracks"""
 
-    class Meta: # type: ignore[misc]
+    class Meta:  # type: ignore[misc]
         model = TransmodelTracks
 
     from_atco_code = factory.Faker("ATCO001")
     to_atco_code = factory.Faker("ATCO001")
-    geometry = factory.LazyFunction(lambda: from_shape(
-        ShapelyLineString([(0, 0), (1, 1), (2, 2)]),
-        srid=4326
-    ))
+    geometry = factory.LazyFunction(
+        lambda: from_shape(ShapelyLineString([(0, 0), (1, 1), (2, 2)]), srid=4326)
+    )
     distance = 10
-

--- a/tests/timetables_etl/etl/transform/test_service_pattern_tracks.py
+++ b/tests/timetables_etl/etl/transform/test_service_pattern_tracks.py
@@ -22,15 +22,20 @@ from timetables_etl.etl.app.transform.service_pattern_tracks import (
 )
 
 
-@patch("timetables_etl.etl.app.transform.service_pattern_tracks.generate_standard_service_tracks")
+@patch(
+    "timetables_etl.etl.app.transform.service_pattern_tracks.generate_standard_service_tracks"
+)
 def test_generate_service_pattern_tracks_standard_service(standard_service_mock: Mock):
     standard_service_mock.return_value = "return_value"
     journey_pattern: TXCJourneyPattern = TXCJourneyPatternFactory()
     tracks = generate_service_pattern_tracks(journey_pattern, 21, {}, [])
     standard_service_mock.assert_called_once()
     assert tracks == "return_value"
-    
-@patch("timetables_etl.etl.app.transform.service_pattern_tracks.generate_flexible_service_tracks")
+
+
+@patch(
+    "timetables_etl.etl.app.transform.service_pattern_tracks.generate_flexible_service_tracks"
+)
 def test_generate_service_pattern_tracks_flexible_service(flexible_service_mock: Mock):
     flexible_service_mock.return_type = None
     journey_pattern: TXCJourneyPattern = TXCFlexibleJourneyPatternFactory()
@@ -38,13 +43,16 @@ def test_generate_service_pattern_tracks_flexible_service(flexible_service_mock:
     flexible_service_mock.assert_called_once()
     assert return_value == []
 
+
 def test_generate_service_pattern_tracks_nonstandard_service():
     with pytest.raises(ValueError):
         generate_service_pattern_tracks("randompattern", 21, {}, [])
 
+
 def test_generate_flexible_service_tracks(caplog: pytest.LogCaptureFixture):
     with caplog.at_level("ERROR"):
         generate_flexible_service_tracks(TXCFlexibleJourneyPatternFactory())
+
 
 def test_generate_standard_service_tracks():
     journey_pattern = TXCJourneyPatternFactory()
@@ -71,25 +79,32 @@ def test_generate_standard_service_tracks():
             location=from_shape(Point(-1.3, 51.3), srid=4326),
         ),
     ]
-    track_lookup:TrackLookup = {
-        ("490001", "490002"): TransmodelTracksFactory(from_atco_code="490001", to_atco_code="490002"),
-        ("490003", "490004"): TransmodelTracksFactory(from_atco_code="490003", to_atco_code="490004")
+    track_lookup: TrackLookup = {
+        ("490001", "490002"): TransmodelTracksFactory(
+            from_atco_code="490001", to_atco_code="490002"
+        ),
+        ("490003", "490004"): TransmodelTracksFactory(
+            from_atco_code="490003", to_atco_code="490004"
+        ),
     }
 
-    sp_tracks = generate_standard_service_tracks(journey_pattern, service_pattern_id, stop_sequence, track_lookup)
-    
+    sp_tracks = generate_standard_service_tracks(
+        journey_pattern, service_pattern_id, stop_sequence, track_lookup
+    )
+
     assert len(sp_tracks) == 2
     assert isinstance(sp_tracks, list)
     assert all(isinstance(track, TransmodelServicePatternTracks) for track in sp_tracks)
-    
+
+
 def test_generate_standard_service_track_with_no_tracks():
     journey_pattern = TXCJourneyPatternFactory()
     service_pattern_id = 21
     stop_sequence: list[NaptanStopPoint] = []
-    track_lookup:TrackLookup = {}
+    track_lookup: TrackLookup = {}
 
-    sp_tracks = generate_standard_service_tracks(journey_pattern, service_pattern_id, stop_sequence, track_lookup)
-    
+    sp_tracks = generate_standard_service_tracks(
+        journey_pattern, service_pattern_id, stop_sequence, track_lookup
+    )
+
     assert len(sp_tracks) == 0
-
-    

--- a/tests/timetables_etl/etl/transform/test_service_pattern_tracks.py
+++ b/tests/timetables_etl/etl/transform/test_service_pattern_tracks.py
@@ -1,0 +1,95 @@
+from unittest.mock import Mock, patch
+
+import pytest
+from common_layer.database.models import NaptanStopPoint, TransmodelServicePatternTracks
+from common_layer.xml.txc.models import (
+    TXCJourneyPattern,
+)
+from geoalchemy2.shape import from_shape
+from shapely import Point
+
+from tests.factories.database import NaptanStopPointFactory
+from tests.factories.database.transmodel import TransmodelTracksFactory
+from tests.timetables_etl.factories.txc import TXCJourneyPatternFactory
+from tests.timetables_etl.factories.txc.factory_txc_service_flexible import (
+    TXCFlexibleJourneyPatternFactory,
+)
+from timetables_etl.etl.app.helpers import TrackLookup
+from timetables_etl.etl.app.transform.service_pattern_tracks import (
+    generate_flexible_service_tracks,
+    generate_service_pattern_tracks,
+    generate_standard_service_tracks,
+)
+
+
+@patch("timetables_etl.etl.app.transform.service_pattern_tracks.generate_standard_service_tracks")
+def test_generate_service_pattern_tracks_standard_service(standard_service_mock: Mock):
+    standard_service_mock.return_value = "return_value"
+    journey_pattern: TXCJourneyPattern = TXCJourneyPatternFactory()
+    tracks = generate_service_pattern_tracks(journey_pattern, 21, {}, [])
+    standard_service_mock.assert_called_once()
+    assert tracks == "return_value"
+    
+@patch("timetables_etl.etl.app.transform.service_pattern_tracks.generate_flexible_service_tracks")
+def test_generate_service_pattern_tracks_flexible_service(flexible_service_mock: Mock):
+    flexible_service_mock.return_type = None
+    journey_pattern: TXCJourneyPattern = TXCFlexibleJourneyPatternFactory()
+    return_value = generate_service_pattern_tracks(journey_pattern, 21, {}, [])
+    flexible_service_mock.assert_called_once()
+    assert return_value == []
+
+def test_generate_service_pattern_tracks_nonstandard_service():
+    with pytest.raises(ValueError):
+        generate_service_pattern_tracks("randompattern", 21, {}, [])
+
+def test_generate_flexible_service_tracks(caplog: pytest.LogCaptureFixture):
+    with caplog.at_level("ERROR"):
+        generate_flexible_service_tracks(TXCFlexibleJourneyPatternFactory())
+
+def test_generate_standard_service_tracks():
+    journey_pattern = TXCJourneyPatternFactory()
+    service_pattern_id = 21
+    stop_sequence: list[NaptanStopPoint] = [
+        NaptanStopPointFactory.create(
+            atco_code="490001",
+            common_name="Origin Stop",
+            location=from_shape(Point(-1.0, 51.0), srid=4326),
+        ),
+        NaptanStopPointFactory.create(
+            atco_code="490002",
+            common_name="Middle Stop",
+            location=from_shape(Point(-1.1, 51.1), srid=4326),
+        ),
+        NaptanStopPointFactory.create(
+            atco_code="490003",
+            common_name="Middle Stop 1",
+            location=from_shape(Point(-1.2, 51.2), srid=4326),
+        ),
+        NaptanStopPointFactory.create(
+            atco_code="490004",
+            common_name="Destination Stop",
+            location=from_shape(Point(-1.3, 51.3), srid=4326),
+        ),
+    ]
+    track_lookup:TrackLookup = {
+        ("490001", "490002"): TransmodelTracksFactory(from_atco_code="490001", to_atco_code="490002"),
+        ("490003", "490004"): TransmodelTracksFactory(from_atco_code="490003", to_atco_code="490004")
+    }
+
+    sp_tracks = generate_standard_service_tracks(journey_pattern, service_pattern_id, stop_sequence, track_lookup)
+    
+    assert len(sp_tracks) == 2
+    assert isinstance(sp_tracks, list)
+    assert all(isinstance(track, TransmodelServicePatternTracks) for track in sp_tracks)
+    
+def test_generate_standard_service_track_with_no_tracks():
+    journey_pattern = TXCJourneyPatternFactory()
+    service_pattern_id = 21
+    stop_sequence: list[NaptanStopPoint] = []
+    track_lookup:TrackLookup = {}
+
+    sp_tracks = generate_standard_service_tracks(journey_pattern, service_pattern_id, stop_sequence, track_lookup)
+    
+    assert len(sp_tracks) == 0
+
+    


### PR DESCRIPTION
Changes are in the PR for the historical tracks data changes
1. Replaced vehicle Journey Tracks entry with Service Pattern Tracks,  Earlier tracks used to be linked with vehicle journeys now it will linked with Service Patterns. 
2. Unique constraint from the tracks will be removed, We will now create each available track in the txc file into the system.

Key Details:

- Model Junction and repo
  - Created new model for service pattern tracks link and repo is created for the same
- Organisation model
  - Added new fields from bods system to serverless repo 
- Load Service Pattern tracks
  - Changes were made to store data in new junction table for service pattern tracks table

JIRA: https://kpmgengineering.atlassian.net/browse/BODS-9044
