### PR TITLE
fix(PTI): convert modification_datetime from int into datetime

### DIFF
--- a/src/boilerplate/common_layer/dynamodb/data_manager.py
+++ b/src/boilerplate/common_layer/dynamodb/data_manager.py
@@ -100,7 +100,7 @@ class FileProcessingDataManager:
             return None
 
         return [
-            TXCFileAttributes(**cached_attribute)  # type: ignore
+            TXCFileAttributes.from_dict(cached_attribute)  # type: ignore
             for cached_attribute in cached_attributes
         ]
 

--- a/src/boilerplate/common_layer/dynamodb/models.py
+++ b/src/boilerplate/common_layer/dynamodb/models.py
@@ -3,7 +3,8 @@ TXC File Attributes Models
 """
 
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
+from decimal import Decimal
 
 from common_layer.database.models.model_organisation import (
     OrganisationTXCFileAttributes,
@@ -29,12 +30,22 @@ class TXCFileAttributes:
         """
         Conversion of TXCFileAttributes from DB into the PTI Model
         """
+        if isinstance(obj.modification_datetime, Decimal):
+            mod_ts_int = int(obj.modification_datetime)
+            modification_dt_formatted = datetime.fromtimestamp(
+                mod_ts_int, tz=timezone.utc
+            )
+        else:
+            modification_dt_formatted = (
+                obj.modification_datetime
+            )  # If it's already a datetime
+
         return TXCFileAttributes(
             id=obj.id,
             revision_number=obj.revision_number,
             service_code=obj.service_code,
             line_names=obj.line_names,
-            modification_datetime=obj.modification_datetime,
+            modification_datetime=modification_dt_formatted,
             hash=obj.hash,
             filename=obj.filename,
         )

--- a/src/boilerplate/common_layer/dynamodb/models.py
+++ b/src/boilerplate/common_layer/dynamodb/models.py
@@ -2,9 +2,12 @@
 TXC File Attributes Models
 """
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from decimal import Decimal
+from typing import Any
 
 from common_layer.database.models.model_organisation import (
     OrganisationTXCFileAttributes,
@@ -24,6 +27,25 @@ class TXCFileAttributes:
     modification_datetime: datetime
     hash: str
     filename: str
+
+    @classmethod
+    def from_dict(cls, txcfileattributes: dict[str, Any]) -> TXCFileAttributes:
+        """
+        Create a TXCFileAttributes instance from a dictionary.
+        Converts Unix timestamp to datetime if needed.
+
+        Args:
+            txcfileattributes: Dictionary with TXC file attributes, where
+            'modification_datetime' is a Unix timestamp (Decimal).
+
+        Returns:
+            TXCFileAttributes: A fully populated instance.
+        """
+        raw_dt: Decimal = txcfileattributes["modification_datetime"]
+        txcfileattributes["modification_datetime"] = datetime.fromtimestamp(
+            float(raw_dt), tz=timezone.utc
+        )
+        return cls(**txcfileattributes)
 
     @staticmethod
     def from_orm(obj: OrganisationTXCFileAttributes):

--- a/src/boilerplate/common_layer/dynamodb/models.py
+++ b/src/boilerplate/common_layer/dynamodb/models.py
@@ -52,22 +52,12 @@ class TXCFileAttributes:
         """
         Conversion of TXCFileAttributes from DB into the PTI Model
         """
-        if isinstance(obj.modification_datetime, Decimal):
-            mod_ts_int = int(obj.modification_datetime)
-            modification_dt_formatted = datetime.fromtimestamp(
-                mod_ts_int, tz=timezone.utc
-            )
-        else:
-            modification_dt_formatted = (
-                obj.modification_datetime
-            )  # If it's already a datetime
-
         return TXCFileAttributes(
             id=obj.id,
             revision_number=obj.revision_number,
             service_code=obj.service_code,
             line_names=obj.line_names,
-            modification_datetime=modification_dt_formatted,
+            modification_datetime=obj.modification_datetime,
             hash=obj.hash,
             filename=obj.filename,
         )


### PR DESCRIPTION
`TXCFileAttributes`'s `modification_datetime` field is not a datetime as it's being pulled from Dynamo cache. Convert it to datetime for comparison purposes soon after pulling data from Dynamo..

JIRA: https://kpmgengineering.atlassian.net/browse/BODS-9209
