### PR TITLE
fix(ETLProcess): Fix track-based distance calculation

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: v1.0.168
+version: v1.0.169

--- a/src/timetables_etl/etl/app/load/servicepatterns_distance.py
+++ b/src/timetables_etl/etl/app/load/servicepatterns_distance.py
@@ -1,3 +1,4 @@
+# pyright: reportUnusedImport=false
 """
 Functions for loading Service Pattern Distance
 """

--- a/src/timetables_etl/etl/app/load/servicepatterns_distance.py
+++ b/src/timetables_etl/etl/app/load/servicepatterns_distance.py
@@ -138,9 +138,11 @@ def process_service_pattern_distance(
             tracks, stop_sequence
         )
     else:
-        api = OSRMGeometryAPI()
-        coords = [(stop.shape.x, stop.shape.y) for stop in stop_sequence]
-        geometry, distance = api.get_geometry_and_distance(coords)
+        return None
+        # TODO: Re-enable once OSRM API deployed
+        # api = OSRMGeometryAPI()
+        # coords = [(stop.shape.x, stop.shape.y) for stop in stop_sequence]
+        # geometry, distance = api.get_geometry_and_distance(coords)
 
     repo = TransmodelServicePatternDistanceRepo(db)
     service_pattern_distance = TransmodelServicePatternDistance(

--- a/src/timetables_etl/etl/app/load/servicepatterns_distance.py
+++ b/src/timetables_etl/etl/app/load/servicepatterns_distance.py
@@ -15,7 +15,6 @@ from shapely import LineString, MultiLineString
 from shapely.ops import linemerge
 from structlog.stdlib import get_logger
 
-from ..api.geometry import OSRMGeometryAPI
 from ..helpers import TrackLookup
 
 log = get_logger()
@@ -139,6 +138,7 @@ def process_service_pattern_distance(
         )
     else:
         return None
+        # pylint: disable=fixme
         # TODO: Re-enable once OSRM API deployed
         # api = OSRMGeometryAPI()
         # coords = [(stop.shape.x, stop.shape.y) for stop in stop_sequence]

--- a/src/timetables_etl/etl/app/load/servicepatterns_distance.py
+++ b/src/timetables_etl/etl/app/load/servicepatterns_distance.py
@@ -70,7 +70,7 @@ def get_geometry_and_distance_from_tracks(
     Calculate the full service geometry and distance using track data
     """
 
-    total_distance = sum(track.distance for track in tracks.values() if track.distance)
+    total_distance: int = 0
     geometry: WKBElement | None = None
 
     track_linestrings: list[LineString] = []
@@ -85,6 +85,9 @@ def get_geometry_and_distance_from_tracks(
             )
         if not track.geometry:
             raise ValueError("Missing geometry for track")
+
+        if track.distance:
+            total_distance += track.distance
 
         shapely_geom = to_shape(track.geometry)
 

--- a/src/timetables_etl/etl/app/load/servicepatterns_distance.py
+++ b/src/timetables_etl/etl/app/load/servicepatterns_distance.py
@@ -15,6 +15,7 @@ from shapely import LineString, MultiLineString
 from shapely.ops import linemerge
 from structlog.stdlib import get_logger
 
+from ..api.geometry import OSRMGeometryAPI  # pylint: disable=unused-import
 from ..helpers import TrackLookup
 
 log = get_logger()

--- a/tests/timetables_etl/etl/load/test_servicepatterns_distance.py
+++ b/tests/timetables_etl/etl/load/test_servicepatterns_distance.py
@@ -166,6 +166,7 @@ def test_process_service_pattern_distance_uses_tracks_data_when_sufficient(
     assert isinstance(inserted_obj.geom, WKBElement)
 
 
+@pytest.mark.skip
 @patch(
     "timetables_etl.etl.app.load.servicepatterns_distance.TransmodelServicePatternDistanceRepo"
 )

--- a/tests/timetables_etl/etl/load/test_servicepatterns_distance.py
+++ b/tests/timetables_etl/etl/load/test_servicepatterns_distance.py
@@ -50,7 +50,17 @@ def sufficient_tracks() -> TrackLookup:
             geometry=from_shape(
                 LineString([(0.01, 0.01), (0.015, 0.015), (0.02, 0.02)]), srid=4326
             ),
-            distance=100,
+            distance=150,
+        ),
+        # Track from another RouteSection
+        # (should not be used because its not in stop_sequence)
+        ("C", "D"): TransmodelTracksFactory.create(
+            from_atco_code="C",
+            to_atco_code="D",
+            geometry=from_shape(
+                LineString([(0.01, 0.01), (0.015, 0.015), (0.02, 0.02)]), srid=4326
+            ),
+            distance=150,
         ),
     }
 
@@ -119,7 +129,7 @@ def test_get_geometry_and_distance_from_tracks(
         sufficient_tracks, stop_sequence
     )
     assert isinstance(geom, WKBElement)
-    assert distance == 200
+    assert distance == 250, "total distance = 100 + 150"
 
 
 @patch(
@@ -136,7 +146,7 @@ def test_process_service_pattern_distance_uses_tracks_data_when_sufficient(
     mock_service.FlexibleService = False
     mock_db = create_autospec(SqlDB, instance=True)
 
-    expected_distance = 200  # 2 tracks * 100 each
+    expected_distance = 250  # 2 tracks, distances 100 + 150
 
     distance = process_service_pattern_distance(
         service=mock_service,


### PR DESCRIPTION
Key details:
- We were summing all of the track distances from the tracks lookup, however this lookup isn't limited to the tracks for the pattern being parsed (it contains tracks for all patterns in the service). 
  - Instead, we should sum only the distances of the tracks that belong in this service pattern.
- The OSRM API doesn't exist in test or prod yet, so it fails in the test env. Disabling this functionality temporarily


JIRA: https://kpmgengineering.atlassian.net/browse/BODS-9210
