### PR TITLE
fix(ETLProcess): Ignored duplicate code

### DIFF
--- a/src/boilerplate/common_layer/database/models/model_transmodel.py
+++ b/src/boilerplate/common_layer/database/models/model_transmodel.py
@@ -161,7 +161,7 @@ class TransmodelServicePatternDistance(BaseSQLModel):
         Geometry("LINESTRING", 4326), nullable=True
     )
     distance: Mapped[int | None] = mapped_column(Integer, nullable=True)
-
+    # pylint: disable=duplicate-code
     service_pattern_id: Mapped[int] = mapped_column(
         Integer,
         ForeignKey(


### PR DESCRIPTION
Added comment for ignoring duplicate code in 
transmodel service pattern tracks table and transmodel service pattern distance table

Key Details:

- transmodel service pattern tracks table and transmodel service pattern distance table
  - We are creating a reference to service pattern table in both db tables and code is marking foreign key as duplicate which is defined in both models
