### PR TITLE
fix(ETLProcess): Cleanup once remote dataset  file is move to s3

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: v1.0.171
+version: v1.0.172

--- a/src/timetables_etl/download_dataset/app/download_dataset.py
+++ b/src/timetables_etl/download_dataset/app/download_dataset.py
@@ -54,6 +54,11 @@ def make_remote_file_name(
 
     return name
 
+def cleanup_temp_folder(path: Path, url: str):
+    """Clean up temporary file on error."""
+    log.error("Upload to S3 complete, removing temp file for cleanup.", url=url, exc_info=True)
+    if path.exists():
+        path.unlink()
 
 def download_and_upload_dataset(db: SqlDB, input_data: DownloadDatasetInputData) -> str:
     """
@@ -66,6 +71,7 @@ def download_and_upload_dataset(db: SqlDB, input_data: DownloadDatasetInputData)
     s3_object_path = make_remote_file_name(revision, result.filetype)
 
     upload_file_to_s3(result.path, input_data.s3_bucket_name, s3_object_path)
+    cleanup_temp_folder(result.path, str(input_data.remote_dataset_url_link))
     update_dataset_revision(db, revision, s3_object_path)
     return s3_object_path
 

--- a/src/timetables_etl/download_dataset/app/download_dataset.py
+++ b/src/timetables_etl/download_dataset/app/download_dataset.py
@@ -54,11 +54,16 @@ def make_remote_file_name(
 
     return name
 
+
+# pylint: disable=duplicate-code
 def cleanup_temp_folder(path: Path, url: str):
     """Clean up temporary file on error."""
-    log.error("Upload to S3 complete, removing temp file for cleanup.", url=url, exc_info=True)
+    log.error(
+        "Upload to S3 complete, removing temp file for cleanup.", url=url, exc_info=True
+    )
     if path.exists():
         path.unlink()
+
 
 def download_and_upload_dataset(db: SqlDB, input_data: DownloadDatasetInputData) -> str:
     """

--- a/src/timetables_etl/download_dataset/app/download_dataset.py
+++ b/src/timetables_etl/download_dataset/app/download_dataset.py
@@ -55,7 +55,6 @@ def make_remote_file_name(
     return name
 
 
-# pylint: disable=duplicate-code
 def cleanup_temp_folder(path: Path, url: str):
     """Clean up temporary file on error."""
     log.error(


### PR DESCRIPTION
No Space left on device error was received at the time of 4PM job,
We have implemented the cleanup code to remove downloaded file from temp dir

Key Details:
- Remove downloaded dataset from temp folder once it is uploaded on S3

JIRA: https://kpmgengineering.atlassian.net/browse/BODS-9252