### PR TITLE
fix(PTI): Normalizing modification_datetime by removing microseconds.

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: v1.0.177
+version: v1.0.178

--- a/src/boilerplate/common_layer/dynamodb/models.py
+++ b/src/boilerplate/common_layer/dynamodb/models.py
@@ -51,13 +51,14 @@ class TXCFileAttributes:
     def from_orm(obj: OrganisationTXCFileAttributes):
         """
         Conversion of TXCFileAttributes from DB into the PTI Model
+        normalizing modification_datetime by removing microseconds.
         """
         return TXCFileAttributes(
             id=obj.id,
             revision_number=obj.revision_number,
             service_code=obj.service_code,
             line_names=obj.line_names,
-            modification_datetime=obj.modification_datetime,
+            modification_datetime=obj.modification_datetime.replace(microsecond=0),
             hash=obj.hash,
             filename=obj.filename,
         )


### PR DESCRIPTION
Problem: Cached modification datetime is saved as int which removed microseconds but the orm returns it with microseconds. Hence the comparison of modification datetime in revision number check logic breaks. 
Fix: Remove the microseconds while reading TXCFileAttributes from the DB


JIRA: https://kpmgengineering.atlassian.net/browse/BODS-9403
