### PR TITLE
fix(TrackConsolidation): Add batching by stop point pairs

### DIFF
--- a/src/periodic_tasks/consolidate_tracks/app/handler_consolidate_tracks.py
+++ b/src/periodic_tasks/consolidate_tracks/app/handler_consolidate_tracks.py
@@ -159,7 +159,3 @@ def lambda_handler(event: dict[str, Any], context: LambdaContext) -> dict[str, A
 
     log.info("Stats", **stats)
     return stats
-
-
-if __name__ == "__main__":
-    lambda_handler({"threshold_meters": "20.0", "dry_run": True}, {})

--- a/src/periodic_tasks/consolidate_tracks/app/handler_consolidate_tracks.py
+++ b/src/periodic_tasks/consolidate_tracks/app/handler_consolidate_tracks.py
@@ -45,53 +45,61 @@ def consolidate_tracks(
         "fks_updated": 0,
     }
 
-    log.info("Streaming similar track pairs")
-    for (
-        from_code,
-        to_code,
-    ), similar_pairs in track_repo.stream_similar_track_pairs_by_stop_points(
-        threshold=threshold
+    batch_size = 10000
+    for batch_idx, stop_point_pairs in enumerate(
+        track_repo.stream_distinct_stop_points_with_multiple_rows(batch_size=batch_size)
     ):
-        log.debug(
-            "Checking stop point pair", from_atco_code=from_code, to_atco_code=to_code
+        log.info(
+            "Streaming similar track pairs",
+            batch_number=batch_idx,
+            batch_size=batch_size,
+            stats=stats,
         )
-        stats["total_pairs_checked"] += 1
+        for (
+            from_code,
+            to_code,
+        ), similar_pairs in track_repo.stream_similar_track_pairs_by_stop_points(
+            stop_point_pairs=stop_point_pairs, threshold=threshold
+        ):
+            if stats["total_pairs_checked"] % 1000 == 0:
+                log.info(
+                    "Pairs checked",
+                    count=stats["total_pairs_checked"],
+                    duration={int(time.perf_counter() - start_time)},
+                )
 
-        if stats["total_pairs_checked"] % 1000 == 0:
-            log.info(
-                "Pairs checked",
-                count=stats["total_pairs_checked"],
-                duration={int(time.perf_counter() - start_time)},
-            )
+            stats["total_pairs_checked"] += 1
 
-        if not similar_pairs:
-            continue
-
-        # Build groups of similar tracks
-        duplicate_groups = build_duplicate_groups(similar_pairs)
-
-        for group in duplicate_groups:
-            if len(group) <= 1:
+            if not similar_pairs:
                 continue
 
-            stats["pairs_with_duplicates"] += 1
-            # Select track with lowest ID (first created) as the canonical track
-            canonical_id = min(group)
+            # Build groups of similar tracks
+            duplicate_groups = build_duplicate_groups(similar_pairs)
 
-            tracks_to_consolidate = [
-                track_id for track_id in group if track_id != canonical_id
-            ]
+            for group in duplicate_groups:
+                if len(group) <= 1:
+                    continue
 
-            if not dry_run:
-                fk_updated_count = sp_track_repo.bulk_replace_service_pattern_tracks(
-                    tracks_to_consolidate, canonical_id
-                )
-                deleted_count = track_repo.bulk_delete_by_ids(tracks_to_consolidate)
+                stats["pairs_with_duplicates"] += 1
+                # Select track with lowest ID (first created) as the canonical track
+                canonical_id = min(group)
 
-                stats["fks_updated"] += fk_updated_count if fk_updated_count else 0
-                stats["tracks_deleted"] += deleted_count if deleted_count else 0
+                tracks_to_consolidate = [
+                    track_id for track_id in group if track_id != canonical_id
+                ]
 
-            stats["tracks_to_delete"] += len(tracks_to_consolidate)
+                if not dry_run:
+                    fk_updated_count = (
+                        sp_track_repo.bulk_replace_service_pattern_tracks(
+                            tracks_to_consolidate, canonical_id
+                        )
+                    )
+                    deleted_count = track_repo.bulk_delete_by_ids(tracks_to_consolidate)
+
+                    stats["fks_updated"] += fk_updated_count if fk_updated_count else 0
+                    stats["tracks_deleted"] += deleted_count if deleted_count else 0
+
+                stats["tracks_to_delete"] += len(tracks_to_consolidate)
 
     return stats
 
@@ -145,3 +153,7 @@ def lambda_handler(event: dict[str, Any], context: LambdaContext) -> dict[str, A
 
     log.info("Stats", **stats)
     return stats
+
+
+if __name__ == "__main__":
+    lambda_handler({"threshold_meters": "20.0", "dry_run": True}, {})

--- a/src/periodic_tasks/consolidate_tracks/app/handler_consolidate_tracks.py
+++ b/src/periodic_tasks/consolidate_tracks/app/handler_consolidate_tracks.py
@@ -24,6 +24,7 @@ tracer = Tracer()
 log = get_logger()
 
 
+# pylint: disable=too-many-locals
 def consolidate_tracks(
     track_repo: TransmodelTrackRepo,
     sp_track_repo: TransmodelServicePatternTracksRepo,
@@ -61,6 +62,11 @@ def consolidate_tracks(
         ), similar_pairs in track_repo.stream_similar_track_pairs_by_stop_points(
             stop_point_pairs=stop_point_pairs, threshold=threshold
         ):
+            log.debug(
+                "Checking stop point pair",
+                from_atco_code=from_code,
+                to_atco_code=to_code,
+            )
             if stats["total_pairs_checked"] % 1000 == 0:
                 log.info(
                     "Pairs checked",

--- a/tests/boilerplate/common_layer/database/repos/test_repo_transmodel.py
+++ b/tests/boilerplate/common_layer/database/repos/test_repo_transmodel.py
@@ -156,7 +156,11 @@ def test_transmodel_tracks_stream_similar_track_pairs_by_stop_points(
             ("A", "C", route_1_coords),  # Different stop points
         ],
     ) as [track1_id, similar_track_id, _, _]:
-        result = list(repo.stream_similar_track_pairs_by_stop_points(threshold=20))
+        result = list(
+            repo.stream_similar_track_pairs_by_stop_points(
+                stop_point_pairs=[("A", "B")], threshold=20
+            )
+        )
 
         assert len(result) == 1
         stop_point_pair, track_pairs = result[0]

--- a/tests/periodic_tasks/consolidate_tracks/test_consolidate_tracks.py
+++ b/tests/periodic_tasks/consolidate_tracks/test_consolidate_tracks.py
@@ -17,7 +17,12 @@ def test_consolidate_tracks_deletes_duplicates(mocker: MockerFixture):
         TransmodelServicePatternTracksRepo, instance=True
     )
 
-    # Simulate similar track pairs grouped by stop point pair
+    # Mock stop point pairs used for batching
+    m_track_repo.stream_distinct_stop_points_with_multiple_rows.return_value = iter(
+        [[("A", "B"), ("C", "D"), ("E", "F")]]  # One batch with all 3
+    )
+
+    # Mock similar track pairs grouped by stop point pair
     similar_tracks_data: list[tuple[tuple[str, str], list[tuple[int, int]]]] = [
         (("A", "B"), [(1, 2), (2, 3), (4, 5)]),  # Grouped: [1,2,3], [4,5]
         (("C", "D"), [(6, 7)]),  # Grouped: [6,7]


### PR DESCRIPTION
With the current volumes, the `stream_similar_track_pairs_by_stop_points` query is running for too long, causing the lambda to time out. In this PR we add batching, so the expensive query runs on a maximum of 10k distinct stop point pairs per call.

I tried runnning it locally against the first million rows of tracks data from production and it took about 5 minutes to go through all of the batches.

The current approach, if the lambda times out waiting on the expensive query, no progress will be made. With this approach, even if the lambda doesn't finish processing all batches, it'll at least consolidate the tracks for the batches that were processed, meaning when the lambda automatically retries, it should continue processing.

JIRA: https://kpmgengineering.atlassian.net/browse/BODS-9077
