### PR TITLE
fix(ETLProcess): Trimmed error message

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: v1.0.176-beta-v1
+version: v1.0.176-beta-v2

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: v1.0.176-beta-v2
+version: v1.0.176-beta-v3

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: v1.0.176
+version: v1.0.176-beta-v1

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: v1.0.181
+version: v1.0.182

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: v1.0.177
+version: v1.0.178

--- a/src/timetables_etl/generate_output_zip/app/output_processing.py
+++ b/src/timetables_etl/generate_output_zip/app/output_processing.py
@@ -132,7 +132,9 @@ def generate_zip_file(
 
         zip_file_keys = [key.split("/")[-1] for key in file_keys]
         with zipfile.ZipFile(file_path, "r") as source_zip:
-            zip_file_list = [key.split("/")[-1] for key in source_zip.namelist()]
+            zip_file_list: dict[str, str] = {
+                key.split("/")[-1]: key for key in source_zip.namelist()
+            }
             missing_files = [key for key in zip_file_keys if key not in zip_file_list]
             if missing_files:
                 log.error(
@@ -155,7 +157,7 @@ def generate_zip_file(
                 for file_key in zip_file_keys:
                     try:
                         log.info(f"Copying {file_key} to new in-memory zip")
-                        file_content = source_zip.read(file_key)
+                        file_content = source_zip.read(zip_file_list[file_key])
                         output_zip.writestr(file_key, file_content)
                         counts.success += 1
                     except (zipfile.BadZipFile, IOError) as e:

--- a/src/timetables_etl/generate_output_zip/app/output_processing.py
+++ b/src/timetables_etl/generate_output_zip/app/output_processing.py
@@ -144,7 +144,7 @@ def generate_zip_file(
                 )
 
                 raise PipelineException(
-                    f"Total Files not found in source zip: {len(missing_files)}",
+                    f"Total files not found in source zip: {len(missing_files)}",
                     "Generate output zipfile",
                 )
 

--- a/src/timetables_etl/generate_output_zip/app/output_processing.py
+++ b/src/timetables_etl/generate_output_zip/app/output_processing.py
@@ -138,11 +138,11 @@ def generate_zip_file(
             missing_files = [key for key in zip_file_keys if key not in zip_file_list]
             if missing_files:
                 log.error(
-                    "Files found in the source zip file", source_files=zip_file_list
+                    "Not all expected files found in source zip",
+                    zip_file_list=zip_file_list,
+                    missing_files=missing_files,
                 )
-                log.error(
-                    "Files not found in source zip: ", missing_files=missing_files
-                )
+
                 raise PipelineException(
                     f"Total Files not found in source zip: {len(missing_files)}",
                     "Generate output zipfile",

--- a/src/timetables_etl/generate_output_zip/app/output_processing.py
+++ b/src/timetables_etl/generate_output_zip/app/output_processing.py
@@ -132,8 +132,7 @@ def generate_zip_file(
 
         zip_file_keys = [key.split("/")[-1] for key in file_keys]
         with zipfile.ZipFile(file_path, "r") as source_zip:
-            # zip_file_list = [key.split("/")[-1] for key in source_zip.namelist()]
-            zip_file_list = source_zip.namelist()
+            zip_file_list = [key.split("/")[-1] for key in source_zip.namelist()]
             missing_files = [key for key in zip_file_keys if key not in zip_file_list]
             if missing_files:
                 log.error(

--- a/src/timetables_etl/generate_output_zip/app/output_processing.py
+++ b/src/timetables_etl/generate_output_zip/app/output_processing.py
@@ -144,7 +144,7 @@ def generate_zip_file(
                     "Files not found in source zip: ", missing_files=missing_files
                 )
                 raise PipelineException(
-                    f"Files not found in source zip: {missing_files}",
+                    f"Total Files not found in source zip: {len(missing_files)}",
                     "Generate output zipfile",
                 )
 

--- a/src/timetables_etl/generate_output_zip/app/output_processing.py
+++ b/src/timetables_etl/generate_output_zip/app/output_processing.py
@@ -3,14 +3,13 @@ Functions to Create and upload zip
 """
 
 import zipfile
+from dataclasses import dataclass
 from io import BytesIO
 from typing import List, Tuple
-from dataclasses import dataclass
 
 from common_layer.aws.step import MapExecutionSucceeded
 from common_layer.s3 import S3
 from structlog.stdlib import get_logger
-
 
 log = get_logger()
 
@@ -130,7 +129,8 @@ def generate_zip_file(
         zip_file_keys = [key.split("/")[-1] for key in file_keys]
 
         with zipfile.ZipFile(file_path, "r") as source_zip:
-            zip_file_list = source_zip.namelist()
+            zip_file_list = [key.split("/")[-1] for key in source_zip.namelist()]
+            log.info("Files found in the source zip file", source_files=zip_file_list)
             missing_files = [key for key in zip_file_keys if key not in zip_file_list]
             if missing_files:
                 log.error(f"Files not found in source zip: {missing_files}")

--- a/src/timetables_etl/generate_output_zip/app/output_processing.py
+++ b/src/timetables_etl/generate_output_zip/app/output_processing.py
@@ -8,6 +8,7 @@ from io import BytesIO
 from typing import List, Tuple
 
 from common_layer.aws.step import MapExecutionSucceeded
+from common_layer.exceptions.pipeline_exceptions import PipelineException
 from common_layer.s3 import S3
 from structlog.stdlib import get_logger
 
@@ -124,17 +125,27 @@ def generate_zip_file(
     try:
         if not get_original_zip(s3_client, original_object_key, file_path):
             log.error(f"Failed to download source zip: {original_object_key}")
-            return (BytesIO(), 0, 0)
+            raise PipelineException(
+                f"Failed to download source zip: {original_object_key}",
+                "Generate output zipfile",
+            )
 
         zip_file_keys = [key.split("/")[-1] for key in file_keys]
-
         with zipfile.ZipFile(file_path, "r") as source_zip:
-            zip_file_list = [key.split("/")[-1] for key in source_zip.namelist()]
-            log.info("Files found in the source zip file", source_files=zip_file_list)
+            # zip_file_list = [key.split("/")[-1] for key in source_zip.namelist()]
+            zip_file_list = source_zip.namelist()
             missing_files = [key for key in zip_file_keys if key not in zip_file_list]
             if missing_files:
-                log.error(f"Files not found in source zip: {missing_files}")
-                return (BytesIO(), 0, 0)
+                log.error(
+                    "Files found in the source zip file", source_files=zip_file_list
+                )
+                log.error(
+                    "Files not found in source zip: ", missing_files=missing_files
+                )
+                raise PipelineException(
+                    f"Files not found in source zip: {missing_files}",
+                    "Generate output zipfile",
+                )
 
             with zipfile.ZipFile(
                 zip_buffer,
@@ -160,15 +171,15 @@ def generate_zip_file(
         log.info(f"Successfully created in-memory zip with {len(file_keys)} files")
         return (zip_buffer, counts.success, counts.failure)
 
-    except zipfile.BadZipFile:
+    except zipfile.BadZipFile as e:
         log.error(f"Invalid zip file: {file_path}", exc_info=True)
-        return (BytesIO(), 0, 0)
+        raise e
     except Exception as e:  # pylint: disable=broad-exception-caught
         log.error(
             f"Unexpected error while processing {original_object_key}: {str(e)}",
             exc_info=True,
         )
-        return (BytesIO(), 0, 0)
+        raise e
 
 
 def process_files(


### PR DESCRIPTION
Error message in the exception caused problem while creating a task error record
Trimmed the message and replaced file names with total number of missing files
Key Details:

- Trimmed the message from generate output lambda and replaced file names with total number of missing files

JIRA: https://kpmgengineering.atlassian.net/browse/BODS-9370
