### PR TITLE
release(test): Trimmed error message (#579)

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: v1.0.181
+version: v1.0.182

--- a/src/timetables_etl/generate_output_zip/app/output_processing.py
+++ b/src/timetables_etl/generate_output_zip/app/output_processing.py
@@ -138,13 +138,13 @@ def generate_zip_file(
             missing_files = [key for key in zip_file_keys if key not in zip_file_list]
             if missing_files:
                 log.error(
-                    "Files found in the source zip file", source_files=zip_file_list
+                    "Not all expected files found in source zip",
+                    zip_file_list=zip_file_list,
+                    missing_files=missing_files,
                 )
-                log.error(
-                    "Files not found in source zip: ", missing_files=missing_files
-                )
+
                 raise PipelineException(
-                    f"Files not found in source zip: {missing_files}",
+                    f"Total files not found in source zip: {len(missing_files)}",
                     "Generate output zipfile",
                 )
 


### PR DESCRIPTION
Error message in the exception caused problem while creating a task error record
Trimmed the message and replaced file names with total number of missing files
Key Details:

- Trimmed the message from generate output lambda and replaced file names with total number of missing files

JIRA: https://kpmgengineering.atlassian.net/browse/BODS-9370
