### PR TITLE
fix(ConsolidateTracks): Modify query to use CTE and reduce batch size

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: v1.0.183
+version: v1.0.184

--- a/src/periodic_tasks/consolidate_tracks/app/handler_consolidate_tracks.py
+++ b/src/periodic_tasks/consolidate_tracks/app/handler_consolidate_tracks.py
@@ -46,7 +46,7 @@ def consolidate_tracks(
         "fks_updated": 0,
     }
 
-    batch_size = 5000
+    batch_size = 500
     for batch_idx, stop_point_pairs in enumerate(
         track_repo.stream_distinct_stop_points_with_multiple_rows(batch_size=batch_size)
     ):


### PR DESCRIPTION
- Use CTE for geometry transformation in query that finds out similar pair of tracks for stop point pair 

- Reduce batch size to 500 so that lambda does not timeout

JIRA: https://kpmgengineering.atlassian.net/browse/BODS-9475
