### PR TITLE
release(UAT): v1.0.187

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: v1.0.186
+version: v1.0.187

--- a/periodic-tasks.yaml
+++ b/periodic-tasks.yaml
@@ -223,8 +223,8 @@ Resources:
           Type: Schedule
           Properties:
             Name: !Sub '${ProjectName}-${Environment}-${SubFunction}-consolidate-tracks-sm-daily'
-            Description: 'Trigger Consolidate Tracks job every day at 2am UTC'
-            Schedule: 'cron(0 2 * * ? *)'
+            Description: 'Trigger Consolidate Tracks job every day at 00:30 UTC'
+            Schedule: 'cron(30 0 * * ? *)'
             Input: !Sub |
               {
                 "threshold_meters": "20.0",


### PR DESCRIPTION
…(https://github.com/department-for-transport-BODS/bods-backend/pull/607)

Consolidate-tracks state machine schedule updated from 02:00 UTC to 00:30 UTC to avoid overlap with 4am (BST) generate timetable job.

JIRA: https://kpmgengineering.atlassian.net/browse/BODS-9550
