### PR TITLE
fix(FaresETLProcess): Incremented aggregation lambda by 1.5GBs

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: v1.0.187
+version: v1.0.188

--- a/fares-etl.yaml
+++ b/fares-etl.yaml
@@ -204,7 +204,7 @@ Resources:
       CodeUri: ./src/fares_etl/metadata_aggregation
       Handler: app.metadata_aggregation.lambda_handler
       Timeout: 900
-      MemorySize: 1024
+      MemorySize: 2500
       Layers:
         - !Ref BoilerplateLambdaLayerArn
       LoggingConfig:


### PR DESCRIPTION
Incremented memory for FaresMetadataAggregation step for large files

Key Details:

Updated memory value SAM template for said lambda:-
  JIRA: https://kpmgengineering.atlassian.net/browse/BODS-9160

