### PR TITLE
fix(ETLProcess): Snap geometries together and save coord distance in new columns

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: v1.0.210
+version: v1.0.211

--- a/src/boilerplate/common_layer/database/models/model_transmodel.py
+++ b/src/boilerplate/common_layer/database/models/model_transmodel.py
@@ -129,7 +129,7 @@ class TransmodelTracks(BaseSQLModel):
         Geometry("LINESTRING", 4326), nullable=True
     )
     distance: Mapped[int | None] = mapped_column(Integer, nullable=True)
-    line_distance: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    coord_distance: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
 
 class TransmodelServicePatternDistance(BaseSQLModel):
@@ -147,7 +147,7 @@ class TransmodelServicePatternDistance(BaseSQLModel):
         Geometry("LINESTRING", 4326), nullable=True
     )
     distance: Mapped[int | None] = mapped_column(Integer, nullable=True)
-    line_distance: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    coord_track_distance: Mapped[int | None] = mapped_column(Integer, nullable=True)
     # pylint: disable=duplicate-code
     service_pattern_id: Mapped[int] = mapped_column(
         Integer,

--- a/src/boilerplate/common_layer/database/models/model_transmodel.py
+++ b/src/boilerplate/common_layer/database/models/model_transmodel.py
@@ -146,6 +146,7 @@ class TransmodelServicePatternDistance(BaseSQLModel):
         Geometry("LINESTRING", 4326), nullable=True
     )
     distance: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    txc_distance: Mapped[int | None] = mapped_column(Integer, nullable=True)
     # pylint: disable=duplicate-code
     service_pattern_id: Mapped[int] = mapped_column(
         Integer,

--- a/src/boilerplate/common_layer/database/models/model_transmodel.py
+++ b/src/boilerplate/common_layer/database/models/model_transmodel.py
@@ -129,6 +129,7 @@ class TransmodelTracks(BaseSQLModel):
         Geometry("LINESTRING", 4326), nullable=True
     )
     distance: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    line_distance: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
 
 class TransmodelServicePatternDistance(BaseSQLModel):
@@ -146,7 +147,7 @@ class TransmodelServicePatternDistance(BaseSQLModel):
         Geometry("LINESTRING", 4326), nullable=True
     )
     distance: Mapped[int | None] = mapped_column(Integer, nullable=True)
-    txc_distance: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    line_distance: Mapped[int | None] = mapped_column(Integer, nullable=True)
     # pylint: disable=duplicate-code
     service_pattern_id: Mapped[int] = mapped_column(
         Integer,

--- a/src/timetables_etl/etl/app/load/servicepatterns_distance.py
+++ b/src/timetables_etl/etl/app/load/servicepatterns_distance.py
@@ -101,7 +101,7 @@ def snap_linestrings(
         )
         curr_coords = list(curr.coords)
         if dist <= tolerance:
-            curr_coords[0] = prev_end  # type: ignore
+            curr_coords[0] = tuple(prev_end)
         snapped.append(LineString(curr_coords))
     return snapped
 

--- a/src/timetables_etl/etl/app/load/servicepatterns_distance.py
+++ b/src/timetables_etl/etl/app/load/servicepatterns_distance.py
@@ -71,25 +71,26 @@ def haversine(lon1: float, lat1: float, lon2: float, lat2: float) -> float:
     """
     Calculate the great-circle distance in meters between two points (lon/lat).
     """
-    R = 6371000  # Earth radius in meters
+    earth_radius = 6371000  # Earth radius in meters
     lon1, lat1, lon2, lat2 = map(radians, [lon1, lat1, lon2, lat2])
     dlon = lon2 - lon1
     dlat = lat2 - lat1
     a = sin(dlat / 2) ** 2 + cos(lat1) * cos(lat2) * sin(dlon / 2) ** 2
     c = 2 * asin(sqrt(a))
-    return R * c
+    return earth_radius * c
 
 
 def snap_linestrings(
     lines: list[LineString], tolerance: float = 15.0
 ) -> list[LineString]:
     """
-    Snap the end of each linestring to the start of the next if they're within the given tolerance (meters).
+    Snap the end of each linestring to the start of the next if they're
+    within the given tolerance (meters).
     """
     if not lines:
         return []
     snapped: list[LineString] = [LineString(lines[0].coords)]
-    for idx, curr in enumerate(lines[1:], start=1):
+    for _idx, curr in enumerate(lines[1:], start=1):
         prev: LineString = snapped[-1]
         prev_end = prev.coords[-1]
         curr_start = curr.coords[0]
@@ -122,7 +123,8 @@ def get_geometry_and_distance_from_tracks(
         track = tracks.get((from_stop.atco_code, to_stop.atco_code))
         if not track or not track.geometry:
             raise ValueError(
-                f"No track or geometry found for stop point pair {from_stop.atco_code} -> {to_stop.atco_code} at index {i}"
+                f"No track or geometry found for stop point \
+                pair {from_stop.atco_code} -> {to_stop.atco_code} at index {i}"
             )
         if track.distance:
             total_distance += track.distance

--- a/src/timetables_etl/etl/app/load/servicepatterns_distance.py
+++ b/src/timetables_etl/etl/app/load/servicepatterns_distance.py
@@ -3,6 +3,8 @@
 Functions for loading Service Pattern Distance
 """
 
+from math import asin, cos, radians, sin, sqrt
+
 from common_layer.database import SqlDB
 from common_layer.database.models import (
     NaptanStopPoint,
@@ -20,6 +22,8 @@ from ..api.geometry import OSRMGeometryAPI
 from ..helpers import TrackLookup
 
 log = get_logger()
+
+SRID = 4326
 
 
 def has_sufficient_track_data(
@@ -63,35 +67,67 @@ def has_sufficient_track_data(
     return True
 
 
+def haversine(lon1: float, lat1: float, lon2: float, lat2: float) -> float:
+    """
+    Calculate the great-circle distance in meters between two points (lon/lat).
+    """
+    R = 6371000  # Earth radius in meters
+    lon1, lat1, lon2, lat2 = map(radians, [lon1, lat1, lon2, lat2])
+    dlon = lon2 - lon1
+    dlat = lat2 - lat1
+    a = sin(dlat / 2) ** 2 + cos(lat1) * cos(lat2) * sin(dlon / 2) ** 2
+    c = 2 * asin(sqrt(a))
+    return R * c
+
+
+def snap_linestrings(
+    lines: list[LineString], tolerance: float = 15.0
+) -> list[LineString]:
+    """
+    Snap the end of each linestring to the start of the next if they're within the given tolerance (meters).
+    """
+    if not lines:
+        return []
+    snapped: list[LineString] = [LineString(lines[0].coords)]
+    for idx, curr in enumerate(lines[1:], start=1):
+        prev: LineString = snapped[-1]
+        prev_end = prev.coords[-1]
+        curr_start = curr.coords[0]
+        dist: float = haversine(
+            float(prev_end[0]),
+            float(prev_end[1]),
+            float(curr_start[0]),
+            float(curr_start[1]),
+        )
+        curr_coords = list(curr.coords)
+        if dist <= tolerance:
+            curr_coords[0] = prev_end  # type: ignore
+        snapped.append(LineString(curr_coords))
+    return snapped
+
+
 def get_geometry_and_distance_from_tracks(
     tracks: TrackLookup,
     stop_sequence: list[NaptanStopPoint],
 ) -> tuple[WKBElement | None, int]:
     """
-    Calculate the full service geometry and distance using track data
+    Calculate the full service geometry and distance using track data,
+    snapping endpoints together within 15 meters.
     """
-
-    total_distance: int = 0
-    geometry: WKBElement | None = None
-
+    total_distance = 0
     track_linestrings: list[LineString] = []
-    for i in range(len(stop_sequence) - 1):
-        from_stop = stop_sequence[i]
-        to_stop = stop_sequence[i + 1]
+    snapped_lines: list[LineString] = []
 
+    for i, (from_stop, to_stop) in enumerate(zip(stop_sequence, stop_sequence[1:])):
         track = tracks.get((from_stop.atco_code, to_stop.atco_code))
-        if not track:
+        if not track or not track.geometry:
             raise ValueError(
-                "No track found for stop point pair",
+                f"No track or geometry found for stop point pair {from_stop.atco_code} -> {to_stop.atco_code} at index {i}"
             )
-        if not track.geometry:
-            raise ValueError("Missing geometry for track")
-
         if track.distance:
             total_distance += track.distance
 
         shapely_geom = to_shape(track.geometry)
-
         if isinstance(shapely_geom, LineString):
             track_linestrings.append(shapely_geom)
         elif isinstance(shapely_geom, MultiLineString):
@@ -99,22 +135,25 @@ def get_geometry_and_distance_from_tracks(
         else:
             log.warning(
                 "Track has unexpected geometry type",
-                track_id=track.id,
+                track_id=getattr(track, "id", "unknown"),
                 geom_type=shapely_geom.geom_type,
             )
 
-    if track_linestrings:
-        merged = linemerge(track_linestrings)
+    if not track_linestrings:
+        log.warning("No valid track geometries found for stop sequence.")
+        return None, 0
 
-        if isinstance(merged, MultiLineString):
-            # Flatten all coordinates into a single LineString
-            coords: list[tuple[float, float]] = []
-            for line in merged.geoms:
-                coords.extend(list(line.coords))  # type: ignore
-            merged = LineString(coords)
+    # Snap endpoints within 15 meters before merging
+    snapped_lines = snap_linestrings(track_linestrings, tolerance=15)
+    merged = linemerge(snapped_lines)
+    if isinstance(merged, MultiLineString):
+        # Flatten all coordinates into a single LineString
+        coords: list[tuple[float, float]] = []
+        for line in merged.geoms:
+            coords.extend(list(line.coords))  # type: ignore
+        merged = LineString(coords)
 
-        geometry = from_shape(merged, srid=4326)
-
+    geometry = from_shape(merged, srid=SRID)
     return geometry, total_distance
 
 

--- a/src/timetables_etl/etl/app/load/servicepatterns_distance.py
+++ b/src/timetables_etl/etl/app/load/servicepatterns_distance.py
@@ -94,10 +94,10 @@ def snap_linestrings(
         prev_end = prev.coords[-1]
         curr_start = curr.coords[0]
         dist: float = haversine(
-            float(prev_end[0]),
-            float(prev_end[1]),
-            float(curr_start[0]),
-            float(curr_start[1]),
+            prev_end[0],
+            prev_end[1],
+            curr_start[0],
+            curr_start[1],
         )
         curr_coords = list(curr.coords)
         if dist <= tolerance:

--- a/src/timetables_etl/etl/app/load/servicepatterns_distance.py
+++ b/src/timetables_etl/etl/app/load/servicepatterns_distance.py
@@ -135,7 +135,7 @@ def get_geometry_and_distance_from_tracks(
         else:
             log.warning(
                 "Track has unexpected geometry type",
-                track_id=getattr(track, "id", "unknown"),
+                track_id=track.id,
                 geom_type=shapely_geom.geom_type,
             )
 

--- a/src/timetables_etl/etl/app/load/servicepatterns_distance.py
+++ b/src/timetables_etl/etl/app/load/servicepatterns_distance.py
@@ -126,7 +126,7 @@ def get_geometry_and_distance_from_tracks(
     snapping endpoints together within 15 meters.
     """
     total_distance = 0
-    total_line_distance = 0
+    total_coord_distance = 0
     track_linestrings: list[LineString] = []
     snapped_lines: list[LineString] = []
 
@@ -141,8 +141,8 @@ def get_geometry_and_distance_from_tracks(
             )
         if track.distance:
             total_distance += track.distance
-        if track.line_distance:
-            total_line_distance += track.line_distance
+        if track.coord_distance:
+            total_coord_distance += track.coord_distance
 
         shapely_geom = to_shape(track.geometry)
         if isinstance(shapely_geom, LineString):
@@ -171,7 +171,7 @@ def get_geometry_and_distance_from_tracks(
         merged = LineString(coords)
 
     geometry = from_shape(merged, srid=SRID)
-    return geometry, total_line_distance, total_distance
+    return geometry, total_coord_distance, total_distance
 
 
 def process_service_pattern_distance(
@@ -189,11 +189,11 @@ def process_service_pattern_distance(
         return None
 
     distance: int | None = None
-    line_distance: int | None = None
+    coord_track_distance: int | None = None
     geometry: WKBElement | None = None
     if tracks and has_sufficient_track_data(tracks, stop_sequence):
-        geometry, line_distance, distance = get_geometry_and_distance_from_tracks(
-            tracks, stop_sequence
+        geometry, coord_track_distance, distance = (
+            get_geometry_and_distance_from_tracks(tracks, stop_sequence)
         )
     else:
         api = OSRMGeometryAPI()
@@ -204,7 +204,7 @@ def process_service_pattern_distance(
     service_pattern_distance = TransmodelServicePatternDistance(
         service_pattern_id=service_pattern_id,
         distance=distance,
-        line_distance=line_distance,
+        coord_track_distance=coord_track_distance,
         geom=geometry,
     )
     repo.insert(service_pattern_distance)

--- a/src/timetables_etl/etl/app/transform/tracks.py
+++ b/src/timetables_etl/etl/app/transform/tracks.py
@@ -176,7 +176,7 @@ def create_new_tracks(route_sections: list[TXCRouteSection]) -> list[TransmodelT
                 if provided_distance is not None
                 else calculate_distance_from_geometry(track_geom.line)
             )
-            line_distance = calculate_distance_from_geometry(track_geom.line)
+            coord_distance = calculate_distance_from_geometry(track_geom.line)
 
             new_tracks.append(
                 TransmodelTracks(
@@ -184,7 +184,7 @@ def create_new_tracks(route_sections: list[TXCRouteSection]) -> list[TransmodelT
                     to_atco_code=to_code,
                     geometry=track_geom.geometry,
                     distance=distance,
-                    line_distance=line_distance,
+                    coord_distance=coord_distance,
                 )
             )
 

--- a/src/timetables_etl/etl/app/transform/tracks.py
+++ b/src/timetables_etl/etl/app/transform/tracks.py
@@ -176,6 +176,7 @@ def create_new_tracks(route_sections: list[TXCRouteSection]) -> list[TransmodelT
                 if provided_distance is not None
                 else calculate_distance_from_geometry(track_geom.line)
             )
+            line_distance = calculate_distance_from_geometry(track_geom.line)
 
             new_tracks.append(
                 TransmodelTracks(
@@ -183,6 +184,7 @@ def create_new_tracks(route_sections: list[TXCRouteSection]) -> list[TransmodelT
                     to_atco_code=to_code,
                     geometry=track_geom.geometry,
                     distance=distance,
+                    line_distance=line_distance,
                 )
             )
 

--- a/tests/factories/database/transmodel.py
+++ b/tests/factories/database/transmodel.py
@@ -196,6 +196,7 @@ class TransmodelTracksFactory(factory.Factory):
     )
 
     distance = factory.LazyFunction(lambda: 1000)  # in meters
+    coord_distance = factory.LazyFunction(lambda: 1000)  # in meters
 
     @classmethod
     def create_with_id(cls, id_number: int, **kwargs) -> TransmodelTracks:

--- a/tests/timetables_etl/etl/load/test_servicepatterns_distance.py
+++ b/tests/timetables_etl/etl/load/test_servicepatterns_distance.py
@@ -125,11 +125,12 @@ def test_has_sufficient_track_data_insufficient_cases(
 def test_get_geometry_and_distance_from_tracks(
     sufficient_tracks: TrackLookup, stop_sequence: list[NaptanStopPoint]
 ) -> None:
-    geom, distance = get_geometry_and_distance_from_tracks(
+    geom, distance, txc_distance = get_geometry_and_distance_from_tracks(
         sufficient_tracks, stop_sequence
     )
     assert isinstance(geom, WKBElement)
-    assert distance == 250, "total distance = 100 + 150"
+    assert txc_distance == 250, "total distance = 100 + 150"
+    assert distance == 3138
 
 
 @patch(

--- a/tests/timetables_etl/etl/load/test_servicepatterns_distance.py
+++ b/tests/timetables_etl/etl/load/test_servicepatterns_distance.py
@@ -43,6 +43,7 @@ def sufficient_tracks() -> TrackLookup:
                 LineString([(0, 0), (0.005, 0.005), (0.01, 0.01)]), srid=4326
             ),
             distance=100,
+            coord_distance=120,
         ),
         ("B", "C"): TransmodelTracksFactory.create(
             from_atco_code="B",
@@ -51,6 +52,7 @@ def sufficient_tracks() -> TrackLookup:
                 LineString([(0.01, 0.01), (0.015, 0.015), (0.02, 0.02)]), srid=4326
             ),
             distance=150,
+            coord_distance=90,
         ),
         # Track from another RouteSection
         # (should not be used because its not in stop_sequence)
@@ -61,6 +63,7 @@ def sufficient_tracks() -> TrackLookup:
                 LineString([(0.01, 0.01), (0.015, 0.015), (0.02, 0.02)]), srid=4326
             ),
             distance=150,
+            coord_distance=110,
         ),
     }
 
@@ -86,6 +89,7 @@ def test_has_sufficient_track_data_true(
                         srid=4326,
                     ),
                     distance=100,
+                    coord_distance=120,
                 ),
             },
             id="missing-track-between-stops",
@@ -100,6 +104,7 @@ def test_has_sufficient_track_data_true(
                         LineString([(0, 0), (0.005, 0.005)]), srid=4326
                     ),
                     distance=100,
+                    coord_distance=120,
                 ),
                 ("B", "C"): TransmodelTracksFactory.create(
                     from_atco_code="B",
@@ -109,6 +114,7 @@ def test_has_sufficient_track_data_true(
                         srid=4326,
                     ),
                     distance=100,
+                    coord_distance=90,
                 ),
             },
             id="insufficient-points-in-track-geometry",
@@ -125,12 +131,12 @@ def test_has_sufficient_track_data_insufficient_cases(
 def test_get_geometry_and_distance_from_tracks(
     sufficient_tracks: TrackLookup, stop_sequence: list[NaptanStopPoint]
 ) -> None:
-    geom, distance, txc_distance = get_geometry_and_distance_from_tracks(
+    geom, total_coord_distance, distance = get_geometry_and_distance_from_tracks(
         sufficient_tracks, stop_sequence
     )
     assert isinstance(geom, WKBElement)
-    assert txc_distance == 250, "total distance = 100 + 150"
-    assert distance == 3138
+    assert distance == 250, "total distance = 100 + 150"
+    assert total_coord_distance == 210
 
 
 @patch(
@@ -148,6 +154,7 @@ def test_process_service_pattern_distance_uses_tracks_data_when_sufficient(
     mock_db = create_autospec(SqlDB, instance=True)
 
     expected_distance = 250  # 2 tracks, distances 100 + 150
+    expected_coord_distance = 210  # 2 tracks, coord distance 120 + 90
 
     distance = process_service_pattern_distance(
         service=mock_service,
@@ -164,6 +171,7 @@ def test_process_service_pattern_distance_uses_tracks_data_when_sufficient(
     inserted_obj = insert_args[0]
     assert inserted_obj.service_pattern_id == 123
     assert inserted_obj.distance == expected_distance
+    assert inserted_obj.coord_track_distance == expected_coord_distance
     assert isinstance(inserted_obj.geom, WKBElement)
 
 
@@ -204,6 +212,7 @@ def test_process_service_pattern_distance_uses_osrm_geom_api(
     inserted_obj = insert_args[0]
     assert inserted_obj.service_pattern_id == 123
     assert inserted_obj.distance == expected_distance
+    assert inserted_obj.coord_track_distance is None
     assert inserted_obj.geom == mock_geom
 
 


### PR DESCRIPTION
Key Details:

- Snap geometries together if end of previous and beginning of next does not coincide
- Save actual coordinates distance for each track in `coord_distance` in `transmodel_tracks` table and the sum of all tracks distance in `coord_track_distance` in `transmodel_servicepatterndistance` table

JIRA: https://kpmgengineering.atlassian.net/browse/BODS-9612 and 
https://kpmgengineering.atlassian.net/browse/BODS-9640
