### PR TITLE
release(Test): Snap geometries together and save coord distance in new columns

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: v1.0.210
+version: v1.0.211

--- a/src/boilerplate/common_layer/database/models/model_transmodel.py
+++ b/src/boilerplate/common_layer/database/models/model_transmodel.py
@@ -129,6 +129,7 @@ class TransmodelTracks(BaseSQLModel):
         Geometry("LINESTRING", 4326), nullable=True
     )
     distance: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    coord_distance: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
 
 class TransmodelServicePatternDistance(BaseSQLModel):
@@ -146,6 +147,7 @@ class TransmodelServicePatternDistance(BaseSQLModel):
         Geometry("LINESTRING", 4326), nullable=True
     )
     distance: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    coord_track_distance: Mapped[int | None] = mapped_column(Integer, nullable=True)
     # pylint: disable=duplicate-code
     service_pattern_id: Mapped[int] = mapped_column(
         Integer,

--- a/src/timetables_etl/etl/app/load/servicepatterns_distance.py
+++ b/src/timetables_etl/etl/app/load/servicepatterns_distance.py
@@ -3,6 +3,8 @@
 Functions for loading Service Pattern Distance
 """
 
+from math import asin, cos, radians, sin, sqrt
+
 from common_layer.database import SqlDB
 from common_layer.database.models import (
     NaptanStopPoint,
@@ -20,6 +22,8 @@ from ..api.geometry import OSRMGeometryAPI
 from ..helpers import TrackLookup
 
 log = get_logger()
+
+SRID = 4326
 
 
 def has_sufficient_track_data(
@@ -63,35 +67,84 @@ def has_sufficient_track_data(
     return True
 
 
+def haversine(lon1: float, lat1: float, lon2: float, lat2: float) -> float:
+    """
+    Calculate the great-circle distance in meters between two points (lon/lat).
+    """
+    earth_radius = 6371000  # Earth radius in meters
+    lon1, lat1, lon2, lat2 = map(radians, [lon1, lat1, lon2, lat2])
+    dlon = lon2 - lon1
+    dlat = lat2 - lat1
+    a = sin(dlat / 2) ** 2 + cos(lat1) * cos(lat2) * sin(dlon / 2) ** 2
+    c = 2 * asin(sqrt(a))
+    return earth_radius * c
+
+
+def snap_linestrings(
+    lines: list[LineString], tolerance: float | None = 15.0
+) -> list[LineString]:
+    """
+    Snap the end of each linestring to the start of the next.
+    If tolerance is None, always snap regardless of distance.
+    Otherwise, snap only when distance <= tolerance (meters).
+    """
+    if not lines:
+        return []
+
+    snapped: list[LineString] = [LineString(lines[0].coords)]
+    for _idx, curr in enumerate(lines[1:], start=1):
+        prev: LineString = snapped[-1]
+        prev_end = prev.coords[-1]
+        curr_start = curr.coords[0]
+
+        curr_coords = list(curr.coords)
+
+        if tolerance is None:
+            # Always snap, skip distance check
+            curr_coords[0] = tuple(prev_end)
+        else:
+            dist: float = haversine(
+                prev_end[0],
+                prev_end[1],
+                curr_start[0],
+                curr_start[1],
+            )
+            if dist <= tolerance:
+                curr_coords[0] = tuple(prev_end)
+
+        snapped.append(LineString(curr_coords))
+
+    return snapped
+
+
 def get_geometry_and_distance_from_tracks(
     tracks: TrackLookup,
     stop_sequence: list[NaptanStopPoint],
-) -> tuple[WKBElement | None, int]:
+) -> tuple[WKBElement | None, int, int]:
     """
-    Calculate the full service geometry and distance using track data
+    Calculate the full service geometry and distance using track data,
+    snapping endpoints together within 15 meters.
     """
-
-    total_distance: int = 0
-    geometry: WKBElement | None = None
-
+    total_distance = 0
+    total_coord_distance = 0
     track_linestrings: list[LineString] = []
-    for i in range(len(stop_sequence) - 1):
-        from_stop = stop_sequence[i]
-        to_stop = stop_sequence[i + 1]
+    snapped_lines: list[LineString] = []
 
+    # Define a projection transformer if your data is in lat/lon (WGS84)
+
+    for i, (from_stop, to_stop) in enumerate(zip(stop_sequence, stop_sequence[1:])):
         track = tracks.get((from_stop.atco_code, to_stop.atco_code))
-        if not track:
+        if not track or not track.geometry:
             raise ValueError(
-                "No track found for stop point pair",
+                f"No track or geometry found for stop point \
+                pair {from_stop.atco_code} -> {to_stop.atco_code} at index {i}"
             )
-        if not track.geometry:
-            raise ValueError("Missing geometry for track")
-
         if track.distance:
             total_distance += track.distance
+        if track.coord_distance:
+            total_coord_distance += track.coord_distance
 
         shapely_geom = to_shape(track.geometry)
-
         if isinstance(shapely_geom, LineString):
             track_linestrings.append(shapely_geom)
         elif isinstance(shapely_geom, MultiLineString):
@@ -103,19 +156,22 @@ def get_geometry_and_distance_from_tracks(
                 geom_type=shapely_geom.geom_type,
             )
 
-    if track_linestrings:
-        merged = linemerge(track_linestrings)
+        if not track_linestrings:
+            log.warning("No valid track geometries found for stop sequence.")
+            return None, 0, 0
 
-        if isinstance(merged, MultiLineString):
-            # Flatten all coordinates into a single LineString
-            coords: list[tuple[float, float]] = []
-            for line in merged.geoms:
-                coords.extend(list(line.coords))  # type: ignore
-            merged = LineString(coords)
+    # Snap endpoints before merging
+    snapped_lines = snap_linestrings(track_linestrings, tolerance=None)
+    merged = linemerge(snapped_lines)
+    if isinstance(merged, MultiLineString):
+        # Flatten all coordinates into a single LineString
+        coords: list[tuple[float, float]] = []
+        for line in merged.geoms:
+            coords.extend(list(line.coords))  # type: ignore
+        merged = LineString(coords)
 
-        geometry = from_shape(merged, srid=4326)
-
-    return geometry, total_distance
+    geometry = from_shape(merged, srid=SRID)
+    return geometry, total_coord_distance, total_distance
 
 
 def process_service_pattern_distance(
@@ -133,10 +189,11 @@ def process_service_pattern_distance(
         return None
 
     distance: int | None = None
+    coord_track_distance: int | None = None
     geometry: WKBElement | None = None
     if tracks and has_sufficient_track_data(tracks, stop_sequence):
-        geometry, distance = get_geometry_and_distance_from_tracks(
-            tracks, stop_sequence
+        geometry, coord_track_distance, distance = (
+            get_geometry_and_distance_from_tracks(tracks, stop_sequence)
         )
     else:
         api = OSRMGeometryAPI()
@@ -145,7 +202,10 @@ def process_service_pattern_distance(
 
     repo = TransmodelServicePatternDistanceRepo(db)
     service_pattern_distance = TransmodelServicePatternDistance(
-        service_pattern_id=service_pattern_id, distance=distance, geom=geometry
+        service_pattern_id=service_pattern_id,
+        distance=distance,
+        coord_track_distance=coord_track_distance,
+        geom=geometry,
     )
     repo.insert(service_pattern_distance)
 

--- a/src/timetables_etl/etl/app/transform/tracks.py
+++ b/src/timetables_etl/etl/app/transform/tracks.py
@@ -176,6 +176,7 @@ def create_new_tracks(route_sections: list[TXCRouteSection]) -> list[TransmodelT
                 if provided_distance is not None
                 else calculate_distance_from_geometry(track_geom.line)
             )
+            coord_distance = calculate_distance_from_geometry(track_geom.line)
 
             new_tracks.append(
                 TransmodelTracks(
@@ -183,6 +184,7 @@ def create_new_tracks(route_sections: list[TXCRouteSection]) -> list[TransmodelT
                     to_atco_code=to_code,
                     geometry=track_geom.geometry,
                     distance=distance,
+                    coord_distance=coord_distance,
                 )
             )
 

--- a/tests/factories/database/transmodel.py
+++ b/tests/factories/database/transmodel.py
@@ -196,6 +196,7 @@ class TransmodelTracksFactory(factory.Factory):
     )
 
     distance = factory.LazyFunction(lambda: 1000)  # in meters
+    coord_distance = factory.LazyFunction(lambda: 1000)  # in meters
 
     @classmethod
     def create_with_id(cls, id_number: int, **kwargs) -> TransmodelTracks:


### PR DESCRIPTION
Key Details:

- Snap geometries together if end of previous and beginning of next does not coincide
- Save actual coordinates distance for each track in `coord_distance` in `transmodel_tracks` table and the sum of all tracks distance in `coord_track_distance` in `transmodel_servicepatterndistance` table

JIRA: https://kpmgengineering.atlassian.net/browse/BODS-9612 and  
https://kpmgengineering.atlassian.net/browse/BODS-9640


JIRA: https://kpmgengineering.atlassian.net/browse/BODS-
