### PR TITLE
fix(fares): Increased memory size to 5120 and EphemeralStorage (temp memory) to 10GB

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: v1.0.214
+version: v1.0.215

--- a/fares-etl.yaml
+++ b/fares-etl.yaml
@@ -217,7 +217,9 @@ Resources:
       CodeUri: ./src/fares_etl/metadata_aggregation
       Handler: app.metadata_aggregation.lambda_handler
       Timeout: 900
-      MemorySize: 2500
+      MemorySize: 5120
+      EphemeralStorage:
+        Size: 10240
       Layers:
         - !Ref BoilerplateLambdaLayerArn
       LoggingConfig:

--- a/timetables-etl.yaml
+++ b/timetables-etl.yaml
@@ -211,9 +211,9 @@ Resources:
       Role: !GetAtt CommonLambdaExecutionRole.Arn
       CodeUri: ./src/timetables_etl/download_dataset
       Handler: app.download_dataset.lambda_handler
-      MemorySize: 1024
+      MemorySize: 5120
       EphemeralStorage:
-        Size: 1024
+        Size: 10240
       Layers:
         - !Ref BoilerplateLambdaLayerArn
       LoggingConfig:
@@ -346,7 +346,9 @@ Resources:
       CodeUri: ./src/timetables_etl/generate_output_zip
       Handler: app.generate_output_zip.lambda_handler
       Timeout: 900
-      MemorySize: 1024
+      MemorySize: 5120
+      EphemeralStorage:
+        Size: 10240
       Layers:
         - !Ref BoilerplateLambdaLayerArn
       LoggingConfig:


### PR DESCRIPTION
Increased memory size to 5120 and EphemeralStorage (temp memory) to 10GB

Key Details:
- Increased memory size to 5120 and EphemeralStorage (temp memory) to 10GB
- Incresed it for following lambdas
bods-backend-<env>-fares-metadata-aggregation-lambda
bods-backend-<env>-tt-generate-output-zip-lambda
bods-backend-<env>-tt-download-dataset-lambda

JIRA: https://kpmgengineering.atlassian.net/browse/BODSHNDOVR-25
