### PR TITLE
release(test): v1.0.217

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: v1.0.216
+version: v1.0.217

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: v1.0.215
+version: v1.0.216

--- a/fares-etl.yaml
+++ b/fares-etl.yaml
@@ -217,7 +217,9 @@ Resources:
       CodeUri: ./src/fares_etl/metadata_aggregation
       Handler: app.metadata_aggregation.lambda_handler
       Timeout: 900
-      MemorySize: 2500
+      MemorySize: 5120
+      EphemeralStorage:
+        Size: 10240
       Layers:
         - !Ref BoilerplateLambdaLayerArn
       LoggingConfig:

--- a/src/common_lambdas/clamav_scanner/app/clamav_scanner.py
+++ b/src/common_lambdas/clamav_scanner/app/clamav_scanner.py
@@ -26,7 +26,7 @@ log = get_logger()
 
 
 def download_and_verify_s3_file(
-    s3_handler: S3, file_key: str, max_size_bytes: int = 800_000_000
+    s3_handler: S3, file_key: str, max_size_bytes: int = 1_500_000_000
 ) -> Path:
     """
     Check file does not exceed max file size and then download it to temp dir

--- a/src/common_lambdas/clamav_scanner/app/verify_file.py
+++ b/src/common_lambdas/clamav_scanner/app/verify_file.py
@@ -40,7 +40,7 @@ def check_for_nested_zips(zip_path: Path) -> tuple[bool, list[str]]:
 
 
 def check_zip_uncompressed_size(
-    zip_path: Path, max_size_bytes: int = 10_000_000_000  # 10GB in bytes
+    zip_path: Path, max_size_bytes: int = 15_000_000_000  # 15GB in bytes
 ) -> tuple[bool, int]:
     """
     Check if the total uncompressed size of files in a ZIP would exceed a maximum size.

--- a/timetables-etl.yaml
+++ b/timetables-etl.yaml
@@ -211,9 +211,9 @@ Resources:
       Role: !GetAtt CommonLambdaExecutionRole.Arn
       CodeUri: ./src/timetables_etl/download_dataset
       Handler: app.download_dataset.lambda_handler
-      MemorySize: 1024
+      MemorySize: 5120
       EphemeralStorage:
-        Size: 1024
+        Size: 10240
       Layers:
         - !Ref BoilerplateLambdaLayerArn
       LoggingConfig:
@@ -346,7 +346,9 @@ Resources:
       CodeUri: ./src/timetables_etl/generate_output_zip
       Handler: app.generate_output_zip.lambda_handler
       Timeout: 900
-      MemorySize: 1024
+      MemorySize: 5120
+      EphemeralStorage:
+        Size: 10240
       Layers:
         - !Ref BoilerplateLambdaLayerArn
       LoggingConfig:


### PR DESCRIPTION
Increased memory size to 5120 and EphemeralStorage (temp memory) to 10GB

Key Details:

 Increased memory size to 5120 and EphemeralStorage (temp memory) to 10GB
- Incresed it for following lambdas
       bods-backend--fares-metadata-aggregation-lambda
       bods-backend--tt-generate-output-zip-lambda 
       bods-backend--tt-download-dataset-lambda
- Increased max upload to 1.5GB and Increase the extracted folder size 15GB