### PR TITLE
fix(routes): Dbods 600 tracks missing bug

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: v1.0.221DBODS600
+version: v1.0.221

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version: v1.0.220
+version: v1.0.221DBODS600

--- a/src/boilerplate/common_layer/xml/txc/models/txc_route.py
+++ b/src/boilerplate/common_layer/xml/txc/models/txc_route.py
@@ -4,6 +4,7 @@ Stop Point
 """
 
 from datetime import datetime
+from typing import Annotated
 
 from pydantic import BaseModel, Field
 
@@ -72,9 +73,12 @@ class TXCRouteLink(BaseModel):
         default=None,
         description=("Distance in metres along the track of the link."),
     )
-    Tracks: list[TXCTrack] = Field(
-        default_factory=list, description="Track Segments in route link - List"
-    )
+    Tracks: Annotated[
+        list[TXCTrack],
+        Field(
+            default_factory=list, description="Track Segments in route link - List"
+        ),
+    ]
 
 
 class TXCRouteSection(BaseModel):
@@ -92,7 +96,7 @@ class TXCRouteSection(BaseModel):
         default=None,
         description="Last modification date and time of the route link.",
     )
-    RouteLink: list[TXCRouteLink] = Field(default_factory=list)
+    RouteLink: Annotated[list[TXCRouteLink], Field(default_factory=list)]
 
 
 class TXCRoute(FrozenBaseModel):

--- a/src/boilerplate/common_layer/xml/txc/models/txc_route.py
+++ b/src/boilerplate/common_layer/xml/txc/models/txc_route.py
@@ -72,7 +72,9 @@ class TXCRouteLink(BaseModel):
         default=None,
         description=("Distance in metres along the track of the link."),
     )
-    Track: TXCTrack | None = Field(default=None)
+    Tracks: list[TXCTrack] = Field(
+        default=[], description="Track Segments in route link - List"
+    )
 
 
 class TXCRouteSection(BaseModel):

--- a/src/boilerplate/common_layer/xml/txc/models/txc_route.py
+++ b/src/boilerplate/common_layer/xml/txc/models/txc_route.py
@@ -73,7 +73,7 @@ class TXCRouteLink(BaseModel):
         description=("Distance in metres along the track of the link."),
     )
     Tracks: list[TXCTrack] = Field(
-        default=[], description="Track Segments in route link - List"
+        default_factory=list, description="Track Segments in route link - List"
     )
 
 
@@ -92,7 +92,7 @@ class TXCRouteSection(BaseModel):
         default=None,
         description="Last modification date and time of the route link.",
     )
-    RouteLink: list[TXCRouteLink] = Field(default=[])
+    RouteLink: list[TXCRouteLink] = Field(default_factory=list)
 
 
 class TXCRoute(FrozenBaseModel):

--- a/src/boilerplate/common_layer/xml/txc/models/txc_route.py
+++ b/src/boilerplate/common_layer/xml/txc/models/txc_route.py
@@ -75,9 +75,7 @@ class TXCRouteLink(BaseModel):
     )
     Tracks: Annotated[
         list[TXCTrack],
-        Field(
-            default_factory=list, description="Track Segments in route link - List"
-        ),
+        Field(default_factory=list, description="Track Segments in route link - List"),
     ]
 
 

--- a/src/boilerplate/common_layer/xml/txc/parser/route_sections.py
+++ b/src/boilerplate/common_layer/xml/txc/parser/route_sections.py
@@ -91,6 +91,20 @@ def parse_track(route_link_xml: _Element) -> TXCTrack | None:
     return None
 
 
+def parse_tracks(route_link_xml: _Element) -> list[TXCTrack]:
+    """
+    Create list of all Tracks for a route link.
+    Handles RouteLinks with multiple Track elements.
+    """
+    tracks: list[TXCTrack] = []
+    track_xmls = route_link_xml.findall("Track")
+    for track_xml in track_xmls:
+        track = parse_track(track_xml)
+        if track:
+            tracks.append(track)
+    return tracks
+
+
 def parse_route_link(
     route_link_xml: _Element, parse_track_data: bool
 ) -> TXCRouteLink | None:
@@ -117,7 +131,7 @@ def parse_route_link(
     revision_number = parse_revision_number(route_link_xml)
     distance = get_element_int(route_link_xml, "Distance")
 
-    track = parse_track(route_link_xml) if parse_track_data else None
+    tracks = parse_tracks(route_link_xml) if parse_track_data else []
 
     return TXCRouteLink(
         id=route_link_id,
@@ -128,7 +142,7 @@ def parse_route_link(
         Modification=modification,
         RevisionNumber=revision_number,
         Distance=distance,
-        Track=track,
+        Tracks=tracks,
     )
 
 

--- a/src/boilerplate/common_layer/xml/txc/parser/route_sections.py
+++ b/src/boilerplate/common_layer/xml/txc/parser/route_sections.py
@@ -78,19 +78,6 @@ def parse_locations(track_xml: _Element) -> list[TXCLocation] | None:
     return None
 
 
-def parse_track(route_link_xml: _Element) -> TXCTrack | None:
-    """
-    Create Track
-    """
-    track_xml = route_link_xml.find("Track")
-    if track_xml is not None:
-        locations = parse_locations(track_xml)
-        if locations:
-            mapping = TXCMapping(Location=locations)
-            return TXCTrack(Mapping=mapping)
-    return None
-
-
 def parse_tracks(route_link_xml: _Element) -> list[TXCTrack]:
     """
     Create list of all Tracks for a route link.

--- a/src/boilerplate/common_layer/xml/txc/parser/route_sections.py
+++ b/src/boilerplate/common_layer/xml/txc/parser/route_sections.py
@@ -99,9 +99,10 @@ def parse_tracks(route_link_xml: _Element) -> list[TXCTrack]:
     tracks: list[TXCTrack] = []
     track_xmls = route_link_xml.findall("Track")
     for track_xml in track_xmls:
-        track = parse_track(track_xml)
-        if track:
-            tracks.append(track)
+        locations = parse_locations(track_xml)
+        if locations:
+            mapping = TXCMapping(Location=locations)
+            tracks.append(TXCTrack(Mapping=mapping))
     return tracks
 
 

--- a/src/timetables_etl/etl/app/load/servicepatterns_distance.py
+++ b/src/timetables_etl/etl/app/load/servicepatterns_distance.py
@@ -9,6 +9,7 @@ from common_layer.database import SqlDB
 from common_layer.database.models import (
     NaptanStopPoint,
     TransmodelServicePatternDistance,
+    TransmodelTracks,
 )
 from common_layer.database.repos import TransmodelServicePatternDistanceRepo
 from common_layer.xml.txc.models import TXCService
@@ -26,45 +27,30 @@ log = get_logger()
 SRID = 4326
 
 
-def has_sufficient_track_data(
+AnalyzedSegment = tuple[NaptanStopPoint, NaptanStopPoint, TransmodelTracks | None]
+
+
+def analyze_track_segments(
     tracks: TrackLookup,
     stop_sequence: list[NaptanStopPoint],
-) -> bool:
+) -> list[AnalyzedSegment]:
     """
-    Check that there is sufficient track data for storing distance info
+    Analyze track data for each stop pair in route order.
 
-    Validates that:
-    - A track exists between every stop in sequence
-    - Each track has a geometry with at least 3 points
+    Returns an ordered list of segments. Each segment includes the track
+    if it exists and has geometry with 3+ points, otherwise None.
     """
-    expected_track_count = len(stop_sequence) - 1
-    for i in range(expected_track_count):
-        from_stop = stop_sequence[i]
-        to_stop = stop_sequence[i + 1]
+    segments: list[AnalyzedSegment] = []
+
+    for from_stop, to_stop in zip(stop_sequence, stop_sequence[1:]):
         track = tracks.get((from_stop.atco_code, to_stop.atco_code))
 
-        if not track:
-            log.warning(
-                "No track data for stop point pair",
-                from_atco_code=from_stop.atco_code,
-                to_atco_code=to_stop.atco_code,
-            )
-            return False
+        if track and track.geometry and len(list(to_shape(track.geometry).coords)) >= 3:
+            segments.append((from_stop, to_stop, track))
+        else:
+            segments.append((from_stop, to_stop, None))
 
-        if not track.geometry:
-            log.warning(
-                "Track has no geometry",
-                track_id=track.id,
-            )
-            return False
-
-        shapely_geom = to_shape(track.geometry)
-        coords = list(shapely_geom.coords)
-        if len(coords) < 3:
-            log.debug(f"Track has insufficient points: {len(coords)}")
-            return False
-
-    return True
+    return segments
 
 
 def haversine(lon1: float, lat1: float, lon2: float, lat2: float) -> float:
@@ -118,57 +104,57 @@ def snap_linestrings(
 
 
 def get_geometry_and_distance_from_tracks(
-    tracks: TrackLookup,
-    stop_sequence: list[NaptanStopPoint],
+    segments: list[AnalyzedSegment],
 ) -> tuple[WKBElement | None, int, int]:
     """
-    Calculate the full service geometry and distance using track data,
-    snapping endpoints together within 15 meters.
+    Calculate the full service geometry and distance in route order.
+    Uses track data for good segments, OSRM for bad segments.
+    Returns (geometry, coord_track_distance, distance).
     """
     total_distance = 0
     total_coord_distance = 0
-    track_linestrings: list[LineString] = []
-    snapped_lines: list[LineString] = []
+    linestrings: list[LineString] = []
+    api: OSRMGeometryAPI | None = None
 
-    # Define a projection transformer if your data is in lat/lon (WGS84)
-
-    for i, (from_stop, to_stop) in enumerate(zip(stop_sequence, stop_sequence[1:])):
-        track = tracks.get((from_stop.atco_code, to_stop.atco_code))
-        if not track or not track.geometry:
-            raise ValueError(
-                f"No track or geometry found for stop point \
-                pair {from_stop.atco_code} -> {to_stop.atco_code} at index {i}"
-            )
-        if track.distance:
-            total_distance += track.distance
-        if track.coord_distance:
-            total_coord_distance += track.coord_distance
-
-        shapely_geom = to_shape(track.geometry)
-        if isinstance(shapely_geom, LineString):
-            track_linestrings.append(shapely_geom)
-        elif isinstance(shapely_geom, MultiLineString):
-            track_linestrings.extend(shapely_geom.geoms)
+    for from_stop, to_stop, track in segments:
+        if track:
+            shapely_geom = to_shape(track.geometry)
+            if isinstance(shapely_geom, LineString):
+                linestrings.append(shapely_geom)
+            elif isinstance(shapely_geom, MultiLineString):
+                linestrings.extend(shapely_geom.geoms)
+            if track.distance:
+                total_distance += track.distance
+            if track.coord_distance:
+                total_coord_distance += track.coord_distance
         else:
-            log.warning(
-                "Track has unexpected geometry type",
-                track_id=track.id,
-                geom_type=shapely_geom.geom_type,
+            if api is None:
+                api = OSRMGeometryAPI()
+            seg_geometry, seg_distance = api.get_geometry_and_distance(
+                [
+                    (from_stop.shape.x, from_stop.shape.y),
+                    (to_stop.shape.x, to_stop.shape.y),
+                ]
             )
+            if seg_geometry:
+                shapely_geom = to_shape(seg_geometry)
+                if isinstance(shapely_geom, LineString):
+                    linestrings.append(shapely_geom)
+                elif isinstance(shapely_geom, MultiLineString):
+                    linestrings.extend(shapely_geom.geoms)
+            if seg_distance:
+                total_distance += seg_distance
 
-        if not track_linestrings:
-            log.warning("No valid track geometries found for stop sequence.")
-            return None, 0, 0
+    if not linestrings:
+        return None, 0, 0
 
-    # Snap endpoints before merging
-    snapped_lines = snap_linestrings(track_linestrings, tolerance=None)
-    merged = linemerge(snapped_lines)
+    snapped = snap_linestrings(linestrings, tolerance=None)
+    merged = linemerge(snapped)
     if isinstance(merged, MultiLineString):
-        # Flatten all coordinates into a single LineString
-        coords: list[tuple[float, float]] = []
+        all_coords: list[tuple[float, float]] = []
         for line in merged.geoms:
-            coords.extend(list(line.coords))  # type: ignore
-        merged = LineString(coords)
+            all_coords.extend(list(line.coords))  # type: ignore
+        merged = LineString(all_coords)
 
     geometry = from_shape(merged, srid=SRID)
     return geometry, total_coord_distance, total_distance
@@ -182,8 +168,8 @@ def process_service_pattern_distance(
     db: SqlDB,
 ) -> int | None:
     """
-    Calculate and store the total distance of this service pattern
-    Uses tracks data if available in the file, else uses distance service
+    Calculate and store the total distance of this service pattern.
+    Uses track data where sufficient, falls back to OSRM per-segment otherwise.
     """
     if service.FlexibleService:
         return None
@@ -191,9 +177,11 @@ def process_service_pattern_distance(
     distance: int | None = None
     coord_track_distance: int | None = None
     geometry: WKBElement | None = None
-    if tracks and has_sufficient_track_data(tracks, stop_sequence):
+
+    if tracks:
+        segments = analyze_track_segments(tracks, stop_sequence)
         geometry, coord_track_distance, distance = (
-            get_geometry_and_distance_from_tracks(tracks, stop_sequence)
+            get_geometry_and_distance_from_tracks(segments)
         )
     else:
         api = OSRMGeometryAPI()

--- a/src/timetables_etl/etl/app/load/servicepatterns_distance.py
+++ b/src/timetables_etl/etl/app/load/servicepatterns_distance.py
@@ -30,6 +30,13 @@ SRID = 4326
 AnalyzedSegment = tuple[NaptanStopPoint, NaptanStopPoint, TransmodelTracks | None]
 
 
+def _count_geometry_coords(geom: LineString | MultiLineString) -> int:
+    """Count total coordinate points in a geometry (handles both LineString and MultiLineString)."""
+    if isinstance(geom, MultiLineString):
+        return sum(len(line.coords) for line in geom.geoms)
+    return len(geom.coords)
+
+
 def analyze_track_segments(
     tracks: TrackLookup,
     stop_sequence: list[NaptanStopPoint],
@@ -45,8 +52,12 @@ def analyze_track_segments(
     for from_stop, to_stop in zip(stop_sequence, stop_sequence[1:]):
         track = tracks.get((from_stop.atco_code, to_stop.atco_code))
 
-        if track and track.geometry and len(list(to_shape(track.geometry).coords)) >= 3:
-            segments.append((from_stop, to_stop, track))
+        if track and track.geometry:
+            shapely_geom = to_shape(track.geometry)
+            if isinstance(shapely_geom, (LineString, MultiLineString)) and _count_geometry_coords(shapely_geom) >= 3:
+                segments.append((from_stop, to_stop, track))
+            else:
+                segments.append((from_stop, to_stop, None))
         else:
             segments.append((from_stop, to_stop, None))
 
@@ -103,14 +114,16 @@ def snap_linestrings(
     return snapped
 
 
-def _add_geometry_to_linestrings(
-    shapely_geom: LineString | MultiLineString, linestrings: list[LineString]
-) -> None:
-    """Add geometry to linestrings list, handling both LineString and MultiLineString."""
-    if isinstance(shapely_geom, LineString):
-        linestrings.append(shapely_geom)
-    elif isinstance(shapely_geom, MultiLineString):
-        linestrings.extend(shapely_geom.geoms)
+def _to_linestring(
+    shapely_geom: LineString | MultiLineString,
+) -> LineString:
+    """Convert geometry to a single LineString, merging if needed."""
+    if isinstance(shapely_geom, MultiLineString):
+        all_coords = []
+        for line in shapely_geom.geoms:
+            all_coords.extend(list(line.coords))  # type: ignore
+        return LineString(all_coords)
+    return shapely_geom
 
 
 def _process_track_segment(
@@ -120,7 +133,12 @@ def _process_track_segment(
     """Process a segment with track data. Returns (distance, coord_distance)."""
     if track.geometry is not None:
         shapely_geom = to_shape(track.geometry)
-        _add_geometry_to_linestrings(shapely_geom, linestrings)
+        if isinstance(shapely_geom, (LineString, MultiLineString)):
+            linestrings.append(_to_linestring(shapely_geom))
+        else:
+            raise TypeError(
+                f"Expected LineString or MultiLineString from track geometry, got {type(shapely_geom).__name__}"
+            )
     return track.distance or 0, track.coord_distance or 0
 
 
@@ -138,7 +156,12 @@ def _process_osrm_segment(
     seg_geometry, seg_distance = api.get_geometry_and_distance(coords)
     if seg_geometry:
         shapely_geom = to_shape(seg_geometry)
-        _add_geometry_to_linestrings(shapely_geom, linestrings)
+        if isinstance(shapely_geom, (LineString, MultiLineString)):
+            linestrings.append(_to_linestring(shapely_geom))
+        else:
+            raise TypeError(
+                f"Expected LineString or MultiLineString from OSRM geometry, got {type(shapely_geom).__name__}"
+            )
     return seg_distance or 0
 
 

--- a/src/timetables_etl/etl/app/load/servicepatterns_distance.py
+++ b/src/timetables_etl/etl/app/load/servicepatterns_distance.py
@@ -122,7 +122,7 @@ def _to_linestring(
 ) -> LineString:
     """Convert geometry to a single LineString, merging if needed."""
     if isinstance(shapely_geom, MultiLineString):
-        all_coords = []
+        all_coords: list[tuple[float, float]] = []
         for line in shapely_geom.geoms:
             all_coords.extend(list(line.coords))  # type: ignore
         return LineString(all_coords)
@@ -140,7 +140,7 @@ def _process_track_segment(
             linestrings.append(_to_linestring(shapely_geom))
         else:
             raise TypeError(
-                f"Expected LineString or MultiLineString from track geometry, got {type(shapely_geom).__name__}"
+                "Expected LineString or MultiLineString from track geometry"
             )
     return track.distance or 0, track.coord_distance or 0
 
@@ -162,9 +162,7 @@ def _process_osrm_segment(
         if isinstance(shapely_geom, (LineString, MultiLineString)):
             linestrings.append(_to_linestring(shapely_geom))
         else:
-            raise TypeError(
-                f"Expected LineString or MultiLineString from OSRM geometry, got {type(shapely_geom).__name__}"
-            )
+            raise TypeError("Expected LineString or MultiLineString from OSRM geometry")
     return seg_distance or 0
 
 

--- a/src/timetables_etl/etl/app/load/servicepatterns_distance.py
+++ b/src/timetables_etl/etl/app/load/servicepatterns_distance.py
@@ -131,27 +131,26 @@ def _to_linestring(
 
 def _process_track_segment(
     track: TransmodelTracks,
-    linestrings: list[LineString],
-) -> tuple[int, int]:
-    """Process a segment with track data. Returns (distance, coord_distance)."""
+ ) -> tuple[LineString | None, int, int]:
+    """Process a segment with track data. Returns (geometry, distance, coord_distance)."""
     if track.geometry is not None:
         shapely_geom = to_shape(track.geometry)
         if isinstance(shapely_geom, (LineString, MultiLineString)):
-            linestrings.append(_to_linestring(shapely_geom))
+            seg_linestring = _to_linestring(shapely_geom)
         else:
             raise TypeError(
                 "Expected LineString or MultiLineString from track geometry"
             )
-    return track.distance or 0, track.coord_distance or 0
+        return seg_linestring, track.distance or 0, track.coord_distance or 0
+    return None, track.distance or 0, track.coord_distance or 0
 
 
 def _process_osrm_segment(
     from_stop: NaptanStopPoint,
     to_stop: NaptanStopPoint,
     api: OSRMGeometryAPI,
-    linestrings: list[LineString],
-) -> int:
-    """Process a segment without track data using OSRM. Returns distance."""
+) -> tuple[LineString | None, int]:
+    """Process a segment without track data using OSRM. Returns (geometry, distance)."""
     coords = [
         (from_stop.shape.x, from_stop.shape.y),
         (to_stop.shape.x, to_stop.shape.y),
@@ -160,10 +159,10 @@ def _process_osrm_segment(
     if seg_geometry:
         shapely_geom = to_shape(seg_geometry)
         if isinstance(shapely_geom, (LineString, MultiLineString)):
-            linestrings.append(_to_linestring(shapely_geom))
+            return _to_linestring(shapely_geom), seg_distance or 0
         else:
             raise TypeError("Expected LineString or MultiLineString from OSRM geometry")
-    return seg_distance or 0
+    return None, seg_distance or 0
 
 
 def _merge_linestrings(linestrings: list[LineString]) -> LineString:
@@ -193,15 +192,20 @@ def get_geometry_and_distance_from_tracks(
 
     for from_stop, to_stop, track in segments:
         if track:
-            distance, coord_distance = _process_track_segment(track, linestrings)
+            segment_geometry, distance, coord_distance = _process_track_segment(track)
+            if segment_geometry is not None:
+                linestrings.append(segment_geometry)
             total_distance += distance
             total_coord_distance += coord_distance
         else:
             if api is None:
                 api = OSRMGeometryAPI()
-            total_distance += _process_osrm_segment(
-                from_stop, to_stop, api, linestrings
+            segment_geometry, segment_distance = _process_osrm_segment(
+                from_stop, to_stop, api
             )
+            if segment_geometry is not None:
+                linestrings.append(segment_geometry)
+            total_distance += segment_distance
 
     if not linestrings:
         return None, 0, 0

--- a/src/timetables_etl/etl/app/load/servicepatterns_distance.py
+++ b/src/timetables_etl/etl/app/load/servicepatterns_distance.py
@@ -103,6 +103,56 @@ def snap_linestrings(
     return snapped
 
 
+def _add_geometry_to_linestrings(
+    shapely_geom: LineString | MultiLineString, linestrings: list[LineString]
+) -> None:
+    """Add geometry to linestrings list, handling both LineString and MultiLineString."""
+    if isinstance(shapely_geom, LineString):
+        linestrings.append(shapely_geom)
+    elif isinstance(shapely_geom, MultiLineString):
+        linestrings.extend(shapely_geom.geoms)
+
+
+def _process_track_segment(
+    track: TransmodelTracks,
+    linestrings: list[LineString],
+) -> tuple[int, int]:
+    """Process a segment with track data. Returns (distance, coord_distance)."""
+    shapely_geom = to_shape(track.geometry)
+    _add_geometry_to_linestrings(shapely_geom, linestrings)
+    return track.distance or 0, track.coord_distance or 0
+
+
+def _process_osrm_segment(
+    from_stop: NaptanStopPoint,
+    to_stop: NaptanStopPoint,
+    api: OSRMGeometryAPI,
+    linestrings: list[LineString],
+) -> int:
+    """Process a segment without track data using OSRM. Returns distance."""
+    coords = [
+        (from_stop.shape.x, from_stop.shape.y),
+        (to_stop.shape.x, to_stop.shape.y),
+    ]
+    seg_geometry, seg_distance = api.get_geometry_and_distance(coords)
+    if seg_geometry:
+        shapely_geom = to_shape(seg_geometry)
+        _add_geometry_to_linestrings(shapely_geom, linestrings)
+    return seg_distance or 0
+
+
+def _merge_linestrings(linestrings: list[LineString]) -> LineString:
+    """Merge and snap linestrings into a single LineString."""
+    snapped = snap_linestrings(linestrings, tolerance=None)
+    merged = linemerge(snapped)
+    if isinstance(merged, MultiLineString):
+        all_coords: list[tuple[float, float]] = []
+        for line in merged.geoms:
+            all_coords.extend(list(line.coords))  # type: ignore
+        merged = LineString(all_coords)
+    return merged
+
+
 def get_geometry_and_distance_from_tracks(
     segments: list[AnalyzedSegment],
 ) -> tuple[WKBElement | None, int, int]:
@@ -118,44 +168,20 @@ def get_geometry_and_distance_from_tracks(
 
     for from_stop, to_stop, track in segments:
         if track:
-            shapely_geom = to_shape(track.geometry)
-            if isinstance(shapely_geom, LineString):
-                linestrings.append(shapely_geom)
-            elif isinstance(shapely_geom, MultiLineString):
-                linestrings.extend(shapely_geom.geoms)
-            if track.distance:
-                total_distance += track.distance
-            if track.coord_distance:
-                total_coord_distance += track.coord_distance
+            distance, coord_distance = _process_track_segment(track, linestrings)
+            total_distance += distance
+            total_coord_distance += coord_distance
         else:
             if api is None:
                 api = OSRMGeometryAPI()
-            seg_geometry, seg_distance = api.get_geometry_and_distance(
-                [
-                    (from_stop.shape.x, from_stop.shape.y),
-                    (to_stop.shape.x, to_stop.shape.y),
-                ]
+            total_distance += _process_osrm_segment(
+                from_stop, to_stop, api, linestrings
             )
-            if seg_geometry:
-                shapely_geom = to_shape(seg_geometry)
-                if isinstance(shapely_geom, LineString):
-                    linestrings.append(shapely_geom)
-                elif isinstance(shapely_geom, MultiLineString):
-                    linestrings.extend(shapely_geom.geoms)
-            if seg_distance:
-                total_distance += seg_distance
 
     if not linestrings:
         return None, 0, 0
 
-    snapped = snap_linestrings(linestrings, tolerance=None)
-    merged = linemerge(snapped)
-    if isinstance(merged, MultiLineString):
-        all_coords: list[tuple[float, float]] = []
-        for line in merged.geoms:
-            all_coords.extend(list(line.coords))  # type: ignore
-        merged = LineString(all_coords)
-
+    merged = _merge_linestrings(linestrings)
     geometry = from_shape(merged, srid=SRID)
     return geometry, total_coord_distance, total_distance
 

--- a/src/timetables_etl/etl/app/load/servicepatterns_distance.py
+++ b/src/timetables_etl/etl/app/load/servicepatterns_distance.py
@@ -118,8 +118,9 @@ def _process_track_segment(
     linestrings: list[LineString],
 ) -> tuple[int, int]:
     """Process a segment with track data. Returns (distance, coord_distance)."""
-    shapely_geom = to_shape(track.geometry)
-    _add_geometry_to_linestrings(shapely_geom, linestrings)
+    if track.geometry is not None:
+        shapely_geom = to_shape(track.geometry)
+        _add_geometry_to_linestrings(shapely_geom, linestrings)
     return track.distance or 0, track.coord_distance or 0
 
 

--- a/src/timetables_etl/etl/app/load/servicepatterns_distance.py
+++ b/src/timetables_etl/etl/app/load/servicepatterns_distance.py
@@ -131,7 +131,7 @@ def _to_linestring(
 
 def _process_track_segment(
     track: TransmodelTracks,
- ) -> tuple[LineString | None, int, int]:
+) -> tuple[LineString | None, int, int]:
     """Process a segment with track data. Returns (geometry, distance, coord_distance)."""
     if track.geometry is not None:
         shapely_geom = to_shape(track.geometry)
@@ -160,8 +160,7 @@ def _process_osrm_segment(
         shapely_geom = to_shape(seg_geometry)
         if isinstance(shapely_geom, (LineString, MultiLineString)):
             return _to_linestring(shapely_geom), seg_distance or 0
-        else:
-            raise TypeError("Expected LineString or MultiLineString from OSRM geometry")
+        raise TypeError("Expected LineString or MultiLineString from OSRM geometry")
     return None, seg_distance or 0
 
 

--- a/src/timetables_etl/etl/app/load/servicepatterns_distance.py
+++ b/src/timetables_etl/etl/app/load/servicepatterns_distance.py
@@ -54,7 +54,10 @@ def analyze_track_segments(
 
         if track and track.geometry:
             shapely_geom = to_shape(track.geometry)
-            if isinstance(shapely_geom, (LineString, MultiLineString)) and _count_geometry_coords(shapely_geom) >= 3:
+            if (
+                isinstance(shapely_geom, (LineString, MultiLineString))
+                and _count_geometry_coords(shapely_geom) >= 3
+            ):
                 segments.append((from_stop, to_stop, track))
             else:
                 segments.append((from_stop, to_stop, None))

--- a/src/timetables_etl/etl/app/transform/service_pattern_mapping.py
+++ b/src/timetables_etl/etl/app/transform/service_pattern_mapping.py
@@ -290,13 +290,14 @@ def process_journey_pattern(
     service_code: str,
     stops_lookup: StopsLookup,
     collections: ServicePatternCollections,
+    txc: TXCData | None = None,
 ) -> None:
     """
     Process a single journey pattern and update the collections
     """
 
     stops = (
-        get_pattern_stops(txc_jp, jps_list, stops_lookup)
+        get_pattern_stops(txc_jp, jps_list, stops_lookup, txc)
         if isinstance(txc_jp, TXCJourneyPattern)
         else get_flexible_pattern_stops(txc_jp, stops_lookup)
     )
@@ -339,7 +340,12 @@ def identify_unique_patterns(
         if service.StandardService:
             for txc_jp in service.StandardService.JourneyPattern:
                 process_journey_pattern(
-                    txc_jp, jps_list, service.ServiceCode, lookups.stops, collections
+                    txc_jp,
+                    jps_list,
+                    service.ServiceCode,
+                    lookups.stops,
+                    collections,
+                    txc,
                 )
 
         if service.FlexibleService:
@@ -350,6 +356,7 @@ def identify_unique_patterns(
                     service.ServiceCode,
                     lookups.stops,
                     collections,
+                    txc,
                 )
 
     return collections

--- a/src/timetables_etl/etl/app/transform/service_pattern_mapping.py
+++ b/src/timetables_etl/etl/app/transform/service_pattern_mapping.py
@@ -290,14 +290,13 @@ def process_journey_pattern(
     service_code: str,
     stops_lookup: StopsLookup,
     collections: ServicePatternCollections,
-    txc: TXCData | None = None,
 ) -> None:
     """
     Process a single journey pattern and update the collections
     """
 
     stops = (
-        get_pattern_stops(txc_jp, jps_list, stops_lookup, txc)
+        get_pattern_stops(txc_jp, jps_list, stops_lookup)
         if isinstance(txc_jp, TXCJourneyPattern)
         else get_flexible_pattern_stops(txc_jp, stops_lookup)
     )
@@ -340,12 +339,7 @@ def identify_unique_patterns(
         if service.StandardService:
             for txc_jp in service.StandardService.JourneyPattern:
                 process_journey_pattern(
-                    txc_jp,
-                    jps_list,
-                    service.ServiceCode,
-                    lookups.stops,
-                    collections,
-                    txc,
+                    txc_jp, jps_list, service.ServiceCode, lookups.stops, collections
                 )
 
         if service.FlexibleService:
@@ -356,7 +350,6 @@ def identify_unique_patterns(
                     service.ServiceCode,
                     lookups.stops,
                     collections,
-                    txc,
                 )
 
     return collections

--- a/src/timetables_etl/etl/app/transform/tracks.py
+++ b/src/timetables_etl/etl/app/transform/tracks.py
@@ -130,7 +130,7 @@ def merge_track_geometries(tracks: list[TXCTrack]) -> TrackGeometry | None:
     if not tracks:
         return None
 
-    all_points: list[Point] = []
+    all_points: list[tuple[float, ...]] = []
 
     for track in tracks:
         track_geom = process_track_geometry(track)

--- a/src/timetables_etl/etl/app/transform/tracks.py
+++ b/src/timetables_etl/etl/app/transform/tracks.py
@@ -156,35 +156,6 @@ def merge_track_geometries(tracks: list[TXCTrack]) -> TrackGeometry | None:
         return None
 
 
-def create_track_mapping(
-    route_sections: list[TXCRouteSection],
-) -> dict[tuple[str, str], tuple[TXCTrack, int | None]]:
-    """
-    Create a mapping from (from_code, to_code) pairs to their corresponding
-    Track and Distance information.
-    """
-
-    route_links_with_track = [
-        route_link
-        for section in route_sections
-        for route_link in section.RouteLink
-        if route_link.Tracks
-    ]
-    track_mapping: dict[tuple[str, str], tuple[TXCTrack, int | None]] = {}
-    for route_link in route_links_with_track:
-        if route_link.Tracks:
-            track_mapping[(route_link.From, route_link.To)] = (
-                route_link.Tracks[0],
-                route_link.Distance,
-            )
-
-    log.info(
-        "Created track mapping",
-        total_mappings=len(track_mapping),
-    )
-    return track_mapping
-
-
 def create_new_tracks(route_sections: list[TXCRouteSection]) -> list[TransmodelTracks]:
     """
     Create new TransmodelTrack objects with geometry and distance where available.

--- a/src/timetables_etl/etl/app/transform/tracks.py
+++ b/src/timetables_etl/etl/app/transform/tracks.py
@@ -97,7 +97,7 @@ def process_track_geometry(track: TXCTrack) -> TrackGeometry | None:
     if len(track.Mapping.Location) < 2:
         log.warning(
             "At least two points are required to make a LineString",
-            point_count=track.Mapping.Location,
+            point_count=len(track.Mapping.Location),
         )
         return None
 
@@ -122,6 +122,40 @@ def process_track_geometry(track: TXCTrack) -> TrackGeometry | None:
         return None
 
 
+def merge_track_geometries(tracks: list[TXCTrack]) -> TrackGeometry | None:
+    """
+    Merge multiple track geometries into a single combined geometry.
+    Used when a RouteLink has multiple Track elements.
+    """
+    if not tracks:
+        return None
+
+    all_points: list[Point] = []
+
+    for track in tracks:
+        track_geom = process_track_geometry(track)
+        if track_geom:
+            all_points.extend(track_geom.line.coords)
+
+    if len(all_points) < 2:
+        log.warning(
+            "Not enough points after merging tracks", total_points=len(all_points)
+        )
+        return None
+
+    try:
+        merged_line = LineString(all_points)
+        geometry = from_shape(merged_line, srid=4326)
+        return TrackGeometry(geometry=geometry, line=merged_line, distance=None)
+    except (ValueError, TypeError) as e:
+        log.warning(
+            "Failed to merge track geometries",
+            error=str(e),
+            track_count=len(tracks),
+        )
+        return None
+
+
 def create_track_mapping(
     route_sections: list[TXCRouteSection],
 ) -> dict[tuple[str, str], tuple[TXCTrack, int | None]]:
@@ -134,13 +168,13 @@ def create_track_mapping(
         route_link
         for section in route_sections
         for route_link in section.RouteLink
-        if route_link.Track
+        if route_link.Tracks
     ]
     track_mapping: dict[tuple[str, str], tuple[TXCTrack, int | None]] = {}
     for route_link in route_links_with_track:
-        if route_link.Track:
+        if route_link.Tracks:
             track_mapping[(route_link.From, route_link.To)] = (
-                route_link.Track,
+                route_link.Tracks[0],
                 route_link.Distance,
             )
 
@@ -154,20 +188,20 @@ def create_track_mapping(
 def create_new_tracks(route_sections: list[TXCRouteSection]) -> list[TransmodelTracks]:
     """
     Create new TransmodelTrack objects with geometry and distance where available.
+    Merges multiple Track elements per RouteLink into a single geometry.
     """
     log.debug("Creating New Tracks")
     new_tracks: list[TransmodelTracks] = []
     for section in route_sections:
         for route_link in section.RouteLink:
-            if not route_link.Track:
+            if not route_link.Tracks:
                 continue
 
             from_code = route_link.From
             to_code = route_link.To
-            txc_track = route_link.Track
             provided_distance = route_link.Distance
 
-            track_geom = process_track_geometry(txc_track)
+            track_geom = merge_track_geometries(route_link.Tracks)
             if not track_geom:
                 continue
 

--- a/tests/timetables_etl/etl/load/test_servicepatterns_distance.py
+++ b/tests/timetables_etl/etl/load/test_servicepatterns_distance.py
@@ -12,8 +12,8 @@ from tests.factories.database.naptan import NaptanStopPointFactory
 from tests.factories.database.transmodel import TransmodelTracksFactory
 from timetables_etl.etl.app.helpers import TrackLookup
 from timetables_etl.etl.app.load.servicepatterns_distance import (
+    analyze_track_segments,
     get_geometry_and_distance_from_tracks,
-    has_sufficient_track_data,
     process_service_pattern_distance,
 )
 
@@ -68,11 +68,17 @@ def sufficient_tracks() -> TrackLookup:
     }
 
 
-def test_has_sufficient_track_data_true(
+def test_analyze_track_segments_all_sufficient(
     sufficient_tracks: TrackLookup,
     stop_sequence: list[NaptanStopPoint],
 ) -> None:
-    assert has_sufficient_track_data(sufficient_tracks, stop_sequence) is True
+    segments = analyze_track_segments(sufficient_tracks, stop_sequence)
+
+    # Should have 2 segments (A->B, B->C)
+    assert len(segments) == 2
+
+    # All segments should have track data (not None)
+    assert all(track is not None for _, _, track in segments)
 
 
 @pytest.mark.parametrize(
@@ -121,18 +127,25 @@ def test_has_sufficient_track_data_true(
         ),
     ],
 )
-def test_has_sufficient_track_data_insufficient_cases(
+def test_analyze_track_segments_insufficient_cases(
     tracks: TrackLookup,
     stop_sequence: list[NaptanStopPoint],
 ) -> None:
-    assert has_sufficient_track_data(tracks, stop_sequence) is False
+    segments = analyze_track_segments(tracks, stop_sequence)
+
+    # Should have 2 segments (A->B, B->C)
+    assert len(segments) == 2
+
+    # At least one segment should have None track (insufficient data)
+    assert any(track is None for _, _, track in segments)
 
 
 def test_get_geometry_and_distance_from_tracks(
     sufficient_tracks: TrackLookup, stop_sequence: list[NaptanStopPoint]
 ) -> None:
+    segments = analyze_track_segments(sufficient_tracks, stop_sequence)
     geom, total_coord_distance, distance = get_geometry_and_distance_from_tracks(
-        sufficient_tracks, stop_sequence
+        segments
     )
     assert isinstance(geom, WKBElement)
     assert distance == 250, "total distance = 100 + 150"

--- a/tests/xml/txc/parser/txc_route_section/test_txc_route_section.py
+++ b/tests/xml/txc/parser/txc_route_section/test_txc_route_section.py
@@ -72,20 +72,22 @@ from lxml import etree
                         Modification="revise",
                         RevisionNumber=5,
                         Distance=1000,
-                        Track=TXCTrack(
-                            Mapping=TXCMapping(
-                                Location=[
-                                    TXCLocation(
-                                        id="loc1",
-                                        Longitude="-0.1234567",
-                                        Latitude="51.9876543",
-                                    ),
-                                    TXCLocation(
-                                        id="loc2", Longitude="0.0", Latitude="0.0"
-                                    ),
-                                ]
+                        Tracks=[
+                            TXCTrack(
+                                Mapping=TXCMapping(
+                                    Location=[
+                                        TXCLocation(
+                                            id="loc1",
+                                            Longitude="-0.1234567",
+                                            Latitude="51.9876543",
+                                        ),
+                                        TXCLocation(
+                                            id="loc2", Longitude="0.0", Latitude="0.0"
+                                        ),
+                                    ]
+                                )
                             )
-                        ),
+                        ],
                     )
                 ],
             ),
@@ -131,7 +133,7 @@ from lxml import etree
                         Modification=None,
                         RevisionNumber=None,
                         Distance=None,
-                        Track=None,
+                        Tracks=[],
                     ),
                     TXCRouteLink(
                         id="RL2",
@@ -146,7 +148,7 @@ from lxml import etree
                         Modification="new",
                         RevisionNumber=1,
                         Distance=800,
-                        Track=None,
+                        Tracks=[],
                     ),
                 ],
             ),
@@ -369,20 +371,22 @@ def test_parse_route_section(xml_string: str, expected: TXCRouteSection) -> None
                             Modification="revise",
                             RevisionNumber=5,
                             Distance=1000,
-                            Track=TXCTrack(
-                                Mapping=TXCMapping(
-                                    Location=[
-                                        TXCLocation(
-                                            id="loc1",
-                                            Longitude="-0.1234567",
-                                            Latitude="51.9876543",
-                                        ),
-                                        TXCLocation(
-                                            id="loc2", Longitude="0.0", Latitude="0.0"
-                                        ),
-                                    ]
+                            Tracks=[
+                                TXCTrack(
+                                    Mapping=TXCMapping(
+                                        Location=[
+                                            TXCLocation(
+                                                id="loc1",
+                                                Longitude="-0.1234567",
+                                                Latitude="51.9876543",
+                                            ),
+                                            TXCLocation(
+                                                id="loc2", Longitude="0.0", Latitude="0.0"
+                                            ),
+                                        ]
+                                    )
                                 )
-                            ),
+                            ],
                         )
                     ],
                 )
@@ -436,7 +440,7 @@ def test_parse_route_section(xml_string: str, expected: TXCRouteSection) -> None
                             Modification=None,
                             RevisionNumber=None,
                             Distance=None,
-                            Track=None,
+                            Tracks=[],
                         )
                     ],
                 ),
@@ -458,7 +462,7 @@ def test_parse_route_section(xml_string: str, expected: TXCRouteSection) -> None
                             Modification="new",
                             RevisionNumber=1,
                             Distance=800,
-                            Track=None,
+                            Tracks=[],
                         )
                     ],
                 ),

--- a/tests/xml/txc/parser/txc_route_section/test_txc_route_section_route_link.py
+++ b/tests/xml/txc/parser/txc_route_section/test_txc_route_section_route_link.py
@@ -34,16 +34,18 @@ from lxml import etree
             </Track>
         </RouteLink>
         """,
-            TXCTrack(
-                Mapping=TXCMapping(
-                    Location=[
-                        TXCLocation(
-                            id="loc1", Longitude="-0.1234567", Latitude="51.9876543"
-                        ),
-                        TXCLocation(id="loc2", Longitude="0.0", Latitude="0.0"),
-                    ]
+            [
+                TXCTrack(
+                    Mapping=TXCMapping(
+                        Location=[
+                            TXCLocation(
+                                id="loc1", Longitude="-0.1234567", Latitude="51.9876543"
+                            ),
+                            TXCLocation(id="loc2", Longitude="0.0", Latitude="0.0"),
+                        ]
+                    )
                 )
-            ),
+            ],
             id="Valid Track",
         ),
         pytest.param(
@@ -59,7 +61,7 @@ from lxml import etree
             </Track>
         </RouteLink>
         """,
-            None,
+            [],
             id="Missing Location ID",
         ),
         pytest.param(
@@ -79,15 +81,17 @@ from lxml import etree
             </Track>
         </RouteLink>
         """,
-            TXCTrack(
-                Mapping=TXCMapping(
-                    Location=[
-                        TXCLocation(
-                            id="loc1", Longitude="-0.1234567", Latitude="51.9876543"
-                        ),
-                    ]
+            [
+                TXCTrack(
+                    Mapping=TXCMapping(
+                        Location=[
+                            TXCLocation(
+                                id="loc1", Longitude="-0.1234567", Latitude="51.9876543"
+                            ),
+                        ]
+                    )
                 )
-            ),
+            ],
             id="Mixed Valid and Invalid Locations",
         ),
         pytest.param(
@@ -103,24 +107,24 @@ from lxml import etree
             </InvalidElement>
         </RouteLink>
         """,
-            None,
+            [],
             id="Invalid Track Element",
         ),
         pytest.param(
             """
         <RouteLink></RouteLink>
         """,
-            None,
+            [],
             id="No Track Element",
         ),
     ],
 )
-def test_parse_track(xml_string: str, expected: TXCTrack | None):
+def test_parse_tracks(xml_string: str, expected: list[TXCTrack]):
     """
     Test the parsing of TXCTrack from XML.
     """
     root = etree.fromstring(xml_string)
-    assert parse_track(root) == expected
+    assert parse_tracks(root) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/xml/txc/parser/txc_route_section/test_txc_route_section_route_link.py
+++ b/tests/xml/txc/parser/txc_route_section/test_txc_route_section_route_link.py
@@ -9,7 +9,6 @@ from common_layer.xml.txc.models import TXCLocation, TXCMapping, TXCRouteLink, T
 from common_layer.xml.txc.parser.route_sections import (
     parse_route_link,
     parse_route_links,
-    parse_track,
     parse_tracks,
 )
 from lxml import etree
@@ -169,7 +168,9 @@ def test_parse_track(xml_string: str, expected: TXCTrack | None):
                         Mapping=TXCMapping(
                             Location=[
                                 TXCLocation(
-                                    id="loc1", Longitude="-0.1234567", Latitude="51.9876543"
+                                    id="loc1",
+                                    Longitude="-0.1234567",
+                                    Latitude="51.9876543",
                                 ),
                                 TXCLocation(id="loc2", Longitude="0.0", Latitude="0.0"),
                             ]
@@ -313,7 +314,9 @@ def test_parse_route_link(xml_string: str, expected: TXCRouteLink | None):
                                         Longitude="-0.1234567",
                                         Latitude="51.9876543",
                                     ),
-                                    TXCLocation(id="loc2", Longitude="0.0", Latitude="0.0"),
+                                    TXCLocation(
+                                        id="loc2", Longitude="0.0", Latitude="0.0"
+                                    ),
                                 ]
                             )
                         )

--- a/tests/xml/txc/parser/txc_route_section/test_txc_route_section_route_link.py
+++ b/tests/xml/txc/parser/txc_route_section/test_txc_route_section_route_link.py
@@ -10,6 +10,7 @@ from common_layer.xml.txc.parser.route_sections import (
     parse_route_link,
     parse_route_links,
     parse_track,
+    parse_tracks,
 )
 from lxml import etree
 
@@ -163,16 +164,18 @@ def test_parse_track(xml_string: str, expected: TXCTrack | None):
                 Modification="revise",
                 RevisionNumber=5,
                 Distance=1000,
-                Track=TXCTrack(
-                    Mapping=TXCMapping(
-                        Location=[
-                            TXCLocation(
-                                id="loc1", Longitude="-0.1234567", Latitude="51.9876543"
-                            ),
-                            TXCLocation(id="loc2", Longitude="0.0", Latitude="0.0"),
-                        ]
+                Tracks=[
+                    TXCTrack(
+                        Mapping=TXCMapping(
+                            Location=[
+                                TXCLocation(
+                                    id="loc1", Longitude="-0.1234567", Latitude="51.9876543"
+                                ),
+                                TXCLocation(id="loc2", Longitude="0.0", Latitude="0.0"),
+                            ]
+                        )
                     )
-                ),
+                ],
             ),
             id="Valid RouteLink",
         ),
@@ -242,7 +245,7 @@ def test_parse_track(xml_string: str, expected: TXCTrack | None):
                 Modification=None,
                 RevisionNumber=None,
                 Distance=None,
-                Track=None,
+                Tracks=[],
             ),
             id="Invalid Track Element",
         ),
@@ -301,18 +304,20 @@ def test_parse_route_link(xml_string: str, expected: TXCRouteLink | None):
                     Modification="revise",
                     RevisionNumber=5,
                     Distance=1000,
-                    Track=TXCTrack(
-                        Mapping=TXCMapping(
-                            Location=[
-                                TXCLocation(
-                                    id="loc1",
-                                    Longitude="-0.1234567",
-                                    Latitude="51.9876543",
-                                ),
-                                TXCLocation(id="loc2", Longitude="0.0", Latitude="0.0"),
-                            ]
+                    Tracks=[
+                        TXCTrack(
+                            Mapping=TXCMapping(
+                                Location=[
+                                    TXCLocation(
+                                        id="loc1",
+                                        Longitude="-0.1234567",
+                                        Latitude="51.9876543",
+                                    ),
+                                    TXCLocation(id="loc2", Longitude="0.0", Latitude="0.0"),
+                                ]
+                            )
                         )
-                    ),
+                    ],
                 )
             ],
             id="Single Valid RouteLink",
@@ -353,7 +358,7 @@ def test_parse_route_link(xml_string: str, expected: TXCRouteLink | None):
                     Modification=None,
                     RevisionNumber=None,
                     Distance=None,
-                    Track=None,
+                    Tracks=[],
                 ),
                 TXCRouteLink(
                     id="RL2",
@@ -366,7 +371,7 @@ def test_parse_route_link(xml_string: str, expected: TXCRouteLink | None):
                     Modification="new",
                     RevisionNumber=1,
                     Distance=800,
-                    Track=None,
+                    Tracks=[],
                 ),
             ],
             id="Multiple RouteLinks",


### PR DESCRIPTION
Fixes issue where predicted path would only be calculated using track data if all Tracks between the stop points had more than two locations per mapping. In the event this previously happened then it would do an API lookup to get road co-ordinates between stops.
## ABODS Output
### 15:40
<img width="934" height="665" alt="image" src="https://github.com/user-attachments/assets/344843ca-cfbd-4406-94c1-454be2774bba" />
### 07:25
<img width="934" height="665" alt="image" src="https://github.com/user-attachments/assets/8df1d16f-7ff8-454c-91e2-8d53d5aeaf5b" />

Desired output route here is the coloured AVL data one 

## Problem Route
### 07:25 - 33031769
<img width="934" height="536" alt="image" src="https://github.com/user-attachments/assets/808f2658-9830-48c5-aa08-b76bdc0ea42c" />

### 15:40 - 33031771
<img width="934" height="536" alt="image" src="https://github.com/user-attachments/assets/32818570-92d3-48b0-ba41-ecee59781f8a" />


## Fixed Route
<img width="934" height="536" alt="image" src="https://github.com/user-attachments/assets/455b2517-fb22-4134-aad6-ab27505c8eae" />


Note: This approach will use the API based lookup for track segments which do not meet the quality threshold of having two location points. This fallback therefor means that it will not always match up with the AVL data. Hence the deviation around Holbeach St Johns